### PR TITLE
Made the Int theory sort unbounded by backing values with BigInteger

### DIFF
--- a/app/src/main/java/charlie/parser/CoraParser.java
+++ b/app/src/main/java/charlie/parser/CoraParser.java
@@ -308,9 +308,7 @@ public class CoraParser {
     if ((token = _status.readNextIf(CoraTokenData.MINUS)) != null) {
       ParserTerm child = readMainTerm();
       if (child == null) return new CalcSymbol(token, MINUS);
-      if (child instanceof IntVal(Token t, BigInteger v)) {
-        return new IntVal(token, v.negate());
-      }
+      if (child instanceof IntVal(Token t, BigInteger v)) return new IntVal(token, v.negate());
       return new Application(token, new CalcSymbol(token, MINUS), FixedList.of(child));
     }
 

--- a/app/src/main/java/charlie/parser/CoraParser.java
+++ b/app/src/main/java/charlie/parser/CoraParser.java
@@ -308,7 +308,9 @@ public class CoraParser {
     if ((token = _status.readNextIf(CoraTokenData.MINUS)) != null) {
       ParserTerm child = readMainTerm();
       if (child == null) return new CalcSymbol(token, MINUS);
-      if (child instanceof IntVal(Token t, BigInteger v)) return new IntVal(token, v.negate());
+      if (child instanceof IntVal(Token t, BigInteger v)) {
+        return new IntVal(token, v.negate());
+      }
       return new Application(token, new CalcSymbol(token, MINUS), FixedList.of(child));
     }
 

--- a/app/src/main/java/charlie/parser/CoraParser.java
+++ b/app/src/main/java/charlie/parser/CoraParser.java
@@ -16,6 +16,7 @@
 package charlie.parser;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.TreeSet;
 
@@ -307,7 +308,7 @@ public class CoraParser {
     if ((token = _status.readNextIf(CoraTokenData.MINUS)) != null) {
       ParserTerm child = readMainTerm();
       if (child == null) return new CalcSymbol(token, MINUS);
-      if (child instanceof IntVal(Token t, int v)) return new IntVal(token, -v);
+      if (child instanceof IntVal(Token t, BigInteger v)) return new IntVal(token, v.negate());
       return new Application(token, new CalcSymbol(token, MINUS), FixedList.of(child));
     }
 
@@ -445,7 +446,7 @@ public class CoraParser {
     if (token.getName().equals(CoraTokenData.FALSE)) return new BoolVal(token, false);
     if (token.getName().equals(CoraTokenData.INTEGER)) {
       try {
-        int number = Integer.parseInt(token.getText());
+        BigInteger number = new BigInteger(token.getText());
         return new IntVal(token, number);
       }
       catch (NumberFormatException e) {

--- a/app/src/main/java/charlie/parser/ITrsParser.java
+++ b/app/src/main/java/charlie/parser/ITrsParser.java
@@ -16,6 +16,7 @@
 package charlie.parser;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 
 import charlie.util.FixedList;
@@ -145,8 +146,8 @@ public class ITrsParser extends FirstOrderParser implements Parser {
     // INTEGER
     token = _status.readNextIf(ITrsTokenData.INTEGER);
     if (token == null) return null;
-    int x = 0;
-    try { x = Integer.parseInt(token.getText()); }
+    BigInteger x = BigInteger.ZERO;
+    try { x = new BigInteger(token.getText()); }
     catch (NumberFormatException ex) {
       _status.storeError(token, "Illegal integer: " + token.getText());
     }

--- a/app/src/main/java/charlie/parser/Parser.java
+++ b/app/src/main/java/charlie/parser/Parser.java
@@ -15,6 +15,7 @@
 
 package charlie.parser;
 
+import java.math.BigInteger;
 import charlie.util.FixedList;
 import charlie.util.LookupMap;
 import charlie.types.Type;
@@ -74,8 +75,8 @@ public interface Parser {
     public String toString() { return istrue ? "TRUE" : "FALSE"; }
     public boolean hasErrors() { return false; }
   }
-  public record IntVal(Token token, int value) implements ParserTerm {
-    public String toString() { return "" + value; }
+  public record IntVal(Token token, BigInteger value) implements ParserTerm {
+    public String toString() { return value.toString(); }
     public boolean hasErrors() { return false; }
   }
   public record StringVal(Token token, String escapedvalue) implements ParserTerm {

--- a/app/src/main/java/charlie/reader/ITrsInputReader.java
+++ b/app/src/main/java/charlie/reader/ITrsInputReader.java
@@ -16,6 +16,7 @@
 package charlie.reader;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
@@ -96,7 +97,7 @@ public class ITrsInputReader {
         ParserTerm s = terms.pop();
         switch (s) {
           case BoolVal(Token token, boolean istrue): continue;  // nothing to do
-          case IntVal(Token token, int value): continue;        // nothing to do
+          case IntVal(Token token, BigInteger value): continue; // nothing to do
           case Identifier(Token token, String name):
             checkFunctionalArities(token, name, FixedList.of(), vars, ret);
             continue;
@@ -208,7 +209,7 @@ public class ITrsInputReader {
     switch (term) {
       case BoolVal(Token token, boolean istrue):
         return boolNode();
-      case IntVal(Token token, int value):
+      case IntVal(Token token, BigInteger value):
         return intNode();
       case Identifier(Token token, String name):
         if (vars.containsKey(name)) return varTypeNode(name, rule);
@@ -330,7 +331,7 @@ public class ITrsInputReader {
     FunctionSymbol f;
 
     switch (term) {
-      case IntVal(Token t, int value):
+      case IntVal(Token t, BigInteger value):
         return TheoryFactory.createValue(value);
       case BoolVal(Token t, boolean isTrue):
         return TheoryFactory.createValue(isTrue);

--- a/app/src/main/java/charlie/reader/TermTyper.java
+++ b/app/src/main/java/charlie/reader/TermTyper.java
@@ -508,8 +508,12 @@ class TermTyper {
     if (args.size() == 2) {
       Term a = targs.get(0);
       Term b = targs.get(1);
-      if (b.isValue()) b = TheoryFactory.createValue(b.toValue().getInteger().negate());
-      else b = TheoryFactory.minusSymbol.apply(b);
+      if (b.isValue()) {
+        b = TheoryFactory.createValue(b.toValue().getInteger().negate());
+      }
+      else {
+        b = TheoryFactory.minusSymbol.apply(b);
+      }
       return confirmType(token, TermFactory.createApp(TheoryFactory.plusSymbol, a, b), expected);
     }
     storeError(token, "Arity error: [-] can be used either with 1 or 2 arguments, but here it " +

--- a/app/src/main/java/charlie/reader/TermTyper.java
+++ b/app/src/main/java/charlie/reader/TermTyper.java
@@ -508,12 +508,8 @@ class TermTyper {
     if (args.size() == 2) {
       Term a = targs.get(0);
       Term b = targs.get(1);
-      if (b.isValue()) {
-        b = TheoryFactory.createValue(b.toValue().getInteger().negate());
-      }
-      else {
-        b = TheoryFactory.minusSymbol.apply(b);
-      }
+      if (b.isValue()) b = TheoryFactory.createValue(b.toValue().getInteger().negate());
+      else b = TheoryFactory.minusSymbol.apply(b);
       return confirmType(token, TermFactory.createApp(TheoryFactory.plusSymbol, a, b), expected);
     }
     storeError(token, "Arity error: [-] can be used either with 1 or 2 arguments, but here it " +

--- a/app/src/main/java/charlie/reader/TermTyper.java
+++ b/app/src/main/java/charlie/reader/TermTyper.java
@@ -15,6 +15,7 @@
 
 package charlie.reader;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 
 import charlie.util.FixedList;
@@ -85,7 +86,7 @@ class TermTyper {
    */
   protected Term makeTerm(ParserTerm pt, Type expectedType, boolean typeShouldBeDerivable) {
     switch (pt) {
-      case IntVal(Token t, int value):
+      case IntVal(Token t, BigInteger value):
         return confirmType(t, TheoryFactory.createValue(value), expectedType);
       case BoolVal(Token t, boolean isTrue):
         return confirmType(t, TheoryFactory.createValue(isTrue), expectedType);
@@ -499,14 +500,15 @@ class TermTyper {
     if (args.size() == 1) {
       Term child = targs.get(0);
       if (child.isValue()) {
-        return confirmType(token, TheoryFactory.createValue(-child.toValue().getInt()), expected);
+        return confirmType(token, TheoryFactory.createValue(child.toValue().getInteger().negate()),
+                           expected);
       }
       return confirmType(token, TheoryFactory.minusSymbol.apply(targs.get(0)), expected);
     }
     if (args.size() == 2) {
       Term a = targs.get(0);
       Term b = targs.get(1);
-      if (b.isValue()) b = TheoryFactory.createValue(-b.toValue().getInt());
+      if (b.isValue()) b = TheoryFactory.createValue(b.toValue().getInteger().negate());
       else b = TheoryFactory.minusSymbol.apply(b);
       return confirmType(token, TermFactory.createApp(TheoryFactory.plusSymbol, a, b), expected);
     }

--- a/app/src/main/java/charlie/smt/Addition.java
+++ b/app/src/main/java/charlie/smt/Addition.java
@@ -15,6 +15,7 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -56,21 +57,21 @@ public final class Addition extends IntegerExpression {
    * Adds a constant to the addition and returns the result.  If the Addition was simplified, then
    * so is the result.
    */
-  public IntegerExpression add(int constant) {
-    if (constant == 0) return this;
+  public IntegerExpression add(BigInteger constant) {
+    if (constant.signum() == 0) return this;
     if (_children.size() == 0) return new IValue(constant);
     if (_children.get(0) instanceof IValue k) {
-      if (k.queryValue() == -constant) {
+      if (k.queryValue().equals(constant.negate())) {
         if (_children.size() == 2) return _children.get(1);
         else return new Addition(_children.subList(1, _children.size()));
       }
       if (_simplified) {
         ArrayList<IntegerExpression> ret = new ArrayList<IntegerExpression>(_children);
-        ret.set(0, new IValue(k.queryValue() + constant));
+        ret.set(0, new IValue(k.queryValue().add(constant)));
         return new Addition(ret, true);
       }
       else {
-        _children.set(0, new IValue(k.queryValue() + constant));
+        _children.set(0, new IValue(k.queryValue().add(constant)));
         Addition ret = new Addition(_children);
         _children.set(0, k);
         return ret;
@@ -100,19 +101,19 @@ public final class Addition extends IntegerExpression {
     ArrayList<IntegerExpression> pos = new ArrayList<IntegerExpression>();
     ArrayList<IntegerExpression> neg = new ArrayList<IntegerExpression>();
 
-    int constant = 0;
+    BigInteger constant = BigInteger.ZERO;
     for (IntegerExpression e : _children) {
-      if (e instanceof IValue k) constant += k.queryValue();
+      if (e instanceof IValue k) constant = constant.add(k.queryValue());
     }
 
-    if (constant > 0) pos.add(new IValue(constant));
-    else if (constant < 0) neg.add(new IValue(-constant));
+    if (constant.signum() > 0) pos.add(new IValue(constant));
+    else if (constant.signum() < 0) neg.add(new IValue(constant.negate()));
 
     for (int i = 0; i < _children.size(); i++) {
       switch (_children.get(i)) {
         case IValue k: continue;
         case CMult cm:
-          if (cm.queryConstant() >= 0) pos.add(cm);
+          if (cm.queryConstant().signum() >= 0) pos.add(cm);
           else neg.add(cm.multiply(-1));
           break;
         default:
@@ -131,9 +132,9 @@ public final class Addition extends IntegerExpression {
     return new Pair<IntegerExpression,IntegerExpression>(p, n);
   }
 
-  public int evaluate(Valuation val) {
-    int ret = 0;
-    for (int i = 0; i < _children.size(); i++) ret += _children.get(i).evaluate(val);
+  public BigInteger evaluate(Valuation val) {
+    BigInteger ret = BigInteger.ZERO;
+    for (int i = 0; i < _children.size(); i++) ret = ret.add(_children.get(i).evaluate(val));
     return ret;
   }
 
@@ -142,7 +143,7 @@ public final class Addition extends IntegerExpression {
     for (int i = 0; i < _children.size(); i++) {
       IntegerExpression child = _children.get(i);
       if (!child.isSimplified()) return;
-      if (child instanceof IValue k && k.queryValue() == 0) return;
+      if (child instanceof IValue k && k.queryValue().signum() == 0) return;
       if (i == 0) continue;
       IntegerExpression childmain = switch(child) {
         case IValue k -> new IValue(1);
@@ -169,36 +170,38 @@ public final class Addition extends IntegerExpression {
       if (c instanceof Addition a) todo.addAll(a._children);
       else todo.add(c);
     }
-    // store the children into a treemap so we can count duplicates, but merge the contants directly
-    TreeMap<IntegerExpression,Integer> counts = new TreeMap<IntegerExpression,Integer>();
-    int constant = 0;
+    // store the children into a treemap so we can count duplicates (i.e. accumulate the coefficient
+    // of each distinct sub-expression), but merge the constants directly.  The accumulated
+    // coefficients are themselves values, so they are tracked as BigIntegers to avoid overflow.
+    TreeMap<IntegerExpression,BigInteger> counts = new TreeMap<IntegerExpression,BigInteger>();
+    BigInteger constant = BigInteger.ZERO;
     for (IntegerExpression c : todo) {
       IntegerExpression main;
-      int num;
-      if (c instanceof IValue k) { constant += k.queryValue(); continue; }
+      BigInteger num;
+      if (c instanceof IValue k) { constant = constant.add(k.queryValue()); continue; }
       else if (c instanceof CMult cm) { main = cm.queryChild(); num = cm.queryConstant(); }
-      else { main = c; num = 1; }
-      Integer current = counts.get(main);
+      else { main = c; num = BigInteger.ONE; }
+      BigInteger current = counts.get(main);
       if (current == null) counts.put(main, num);
-      else counts.put(main, num + current);
+      else counts.put(main, num.add(current));
     }
     // read them out
     ArrayList<IntegerExpression> ret = new ArrayList<IntegerExpression>();
-    if (constant != 0) ret.add(new IValue(constant));
-    for (Map.Entry<IntegerExpression,Integer> entry : counts.entrySet()) {
-      int k = entry.getValue();
-      if (k == 1) ret.add(entry.getKey());
-      else if (k != 0) ret.add(new CMult(k, entry.getKey()));
+    if (constant.signum() != 0) ret.add(new IValue(constant));
+    for (Map.Entry<IntegerExpression,BigInteger> entry : counts.entrySet()) {
+      BigInteger k = entry.getValue();
+      if (k.equals(BigInteger.ONE)) ret.add(entry.getKey());
+      else if (k.signum() != 0) ret.add(new CMult(k, entry.getKey()));
     }
     // return the result
-    if (ret.size() == 0) return new IValue(0);
+    if (ret.size() == 0) return new IValue(BigInteger.ZERO);
     if (ret.size() == 1) return ret.get(0);
     return new Addition(ret, true);
   }
 
-  public IntegerExpression multiply(int constant) {
-    if (constant == 0) return new IValue(0);
-    if (constant == 1) return this;
+  public IntegerExpression multiply(BigInteger constant) {
+    if (constant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (constant.equals(BigInteger.ONE)) return this;
     ArrayList<IntegerExpression> cs = new ArrayList<IntegerExpression>();
     for (int i = 0; i < _children.size(); i++) cs.add(_children.get(i).multiply(constant));
     return new Addition(cs, _simplified);

--- a/app/src/main/java/charlie/smt/Addition.java
+++ b/app/src/main/java/charlie/smt/Addition.java
@@ -58,9 +58,7 @@ public final class Addition extends IntegerExpression {
    * so is the result.
    */
   public IntegerExpression add(BigInteger constant) {
-    if (constant.signum() == 0) {
-      return this;
-    }
+    if (constant.signum() == 0) return this;
     if (_children.size() == 0) return new IValue(constant);
     if (_children.get(0) instanceof IValue k) {
       if (k.queryValue().equals(constant.negate())) {
@@ -105,28 +103,18 @@ public final class Addition extends IntegerExpression {
 
     BigInteger constant = BigInteger.ZERO;
     for (IntegerExpression e : _children) {
-      if (e instanceof IValue k) {
-        constant = constant.add(k.queryValue());
-      }
+      if (e instanceof IValue k) constant = constant.add(k.queryValue());
     }
 
-    if (constant.signum() > 0) {
-      pos.add(new IValue(constant));
-    }
-    else if (constant.signum() < 0) {
-      neg.add(new IValue(constant.negate()));
-    }
+    if (constant.signum() > 0) pos.add(new IValue(constant));
+    else if (constant.signum() < 0) neg.add(new IValue(constant.negate()));
 
     for (int i = 0; i < _children.size(); i++) {
       switch (_children.get(i)) {
         case IValue k: continue;
         case CMult cm:
-          if (cm.queryConstant().signum() >= 0) {
-            pos.add(cm);
-          }
-          else {
-            neg.add(cm.multiply(-1));
-          }
+          if (cm.queryConstant().signum() >= 0) pos.add(cm);
+          else neg.add(cm.multiply(-1));
           break;
         default:
           pos.add(_children.get(i));
@@ -146,9 +134,7 @@ public final class Addition extends IntegerExpression {
 
   public BigInteger evaluate(Valuation val) {
     BigInteger ret = BigInteger.ZERO;
-    for (int i = 0; i < _children.size(); i++) {
-      ret = ret.add(_children.get(i).evaluate(val));
-    }
+    for (int i = 0; i < _children.size(); i++) ret = ret.add(_children.get(i).evaluate(val));
     return ret;
   }
 
@@ -157,9 +143,7 @@ public final class Addition extends IntegerExpression {
     for (int i = 0; i < _children.size(); i++) {
       IntegerExpression child = _children.get(i);
       if (!child.isSimplified()) return;
-      if (child instanceof IValue k && k.queryValue().signum() == 0) {
-        return;
-      }
+      if (child instanceof IValue k && k.queryValue().signum() == 0) return;
       if (i == 0) continue;
       IntegerExpression childmain = switch(child) {
         case IValue k -> new IValue(1);
@@ -199,39 +183,25 @@ public final class Addition extends IntegerExpression {
       else { main = c; num = BigInteger.ONE; }
       BigInteger current = counts.get(main);
       if (current == null) counts.put(main, num);
-      else {
-        counts.put(main, num.add(current));
-      }
+      else counts.put(main, num.add(current));
     }
     // read them out
     ArrayList<IntegerExpression> ret = new ArrayList<IntegerExpression>();
-    if (constant.signum() != 0) {
-      ret.add(new IValue(constant));
-    }
+    if (constant.signum() != 0) ret.add(new IValue(constant));
     for (Map.Entry<IntegerExpression,BigInteger> entry : counts.entrySet()) {
       BigInteger k = entry.getValue();
-      if (k.equals(BigInteger.ONE)) {
-        ret.add(entry.getKey());
-      }
-      else if (k.signum() != 0) {
-        ret.add(new CMult(k, entry.getKey()));
-      }
+      if (k.equals(BigInteger.ONE)) ret.add(entry.getKey());
+      else if (k.signum() != 0) ret.add(new CMult(k, entry.getKey()));
     }
     // return the result
-    if (ret.size() == 0) {
-      return new IValue(BigInteger.ZERO);
-    }
+    if (ret.size() == 0) return new IValue(BigInteger.ZERO);
     if (ret.size() == 1) return ret.get(0);
     return new Addition(ret, true);
   }
 
   public IntegerExpression multiply(BigInteger constant) {
-    if (constant.signum() == 0) {
-      return new IValue(BigInteger.ZERO);
-    }
-    if (constant.equals(BigInteger.ONE)) {
-      return this;
-    }
+    if (constant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (constant.equals(BigInteger.ONE)) return this;
     ArrayList<IntegerExpression> cs = new ArrayList<IntegerExpression>();
     for (int i = 0; i < _children.size(); i++) cs.add(_children.get(i).multiply(constant));
     return new Addition(cs, _simplified);

--- a/app/src/main/java/charlie/smt/Addition.java
+++ b/app/src/main/java/charlie/smt/Addition.java
@@ -58,7 +58,9 @@ public final class Addition extends IntegerExpression {
    * so is the result.
    */
   public IntegerExpression add(BigInteger constant) {
-    if (constant.signum() == 0) return this;
+    if (constant.signum() == 0) {
+      return this;
+    }
     if (_children.size() == 0) return new IValue(constant);
     if (_children.get(0) instanceof IValue k) {
       if (k.queryValue().equals(constant.negate())) {
@@ -103,18 +105,28 @@ public final class Addition extends IntegerExpression {
 
     BigInteger constant = BigInteger.ZERO;
     for (IntegerExpression e : _children) {
-      if (e instanceof IValue k) constant = constant.add(k.queryValue());
+      if (e instanceof IValue k) {
+        constant = constant.add(k.queryValue());
+      }
     }
 
-    if (constant.signum() > 0) pos.add(new IValue(constant));
-    else if (constant.signum() < 0) neg.add(new IValue(constant.negate()));
+    if (constant.signum() > 0) {
+      pos.add(new IValue(constant));
+    }
+    else if (constant.signum() < 0) {
+      neg.add(new IValue(constant.negate()));
+    }
 
     for (int i = 0; i < _children.size(); i++) {
       switch (_children.get(i)) {
         case IValue k: continue;
         case CMult cm:
-          if (cm.queryConstant().signum() >= 0) pos.add(cm);
-          else neg.add(cm.multiply(-1));
+          if (cm.queryConstant().signum() >= 0) {
+            pos.add(cm);
+          }
+          else {
+            neg.add(cm.multiply(-1));
+          }
           break;
         default:
           pos.add(_children.get(i));
@@ -134,7 +146,9 @@ public final class Addition extends IntegerExpression {
 
   public BigInteger evaluate(Valuation val) {
     BigInteger ret = BigInteger.ZERO;
-    for (int i = 0; i < _children.size(); i++) ret = ret.add(_children.get(i).evaluate(val));
+    for (int i = 0; i < _children.size(); i++) {
+      ret = ret.add(_children.get(i).evaluate(val));
+    }
     return ret;
   }
 
@@ -143,7 +157,9 @@ public final class Addition extends IntegerExpression {
     for (int i = 0; i < _children.size(); i++) {
       IntegerExpression child = _children.get(i);
       if (!child.isSimplified()) return;
-      if (child instanceof IValue k && k.queryValue().signum() == 0) return;
+      if (child instanceof IValue k && k.queryValue().signum() == 0) {
+        return;
+      }
       if (i == 0) continue;
       IntegerExpression childmain = switch(child) {
         case IValue k -> new IValue(1);
@@ -183,25 +199,39 @@ public final class Addition extends IntegerExpression {
       else { main = c; num = BigInteger.ONE; }
       BigInteger current = counts.get(main);
       if (current == null) counts.put(main, num);
-      else counts.put(main, num.add(current));
+      else {
+        counts.put(main, num.add(current));
+      }
     }
     // read them out
     ArrayList<IntegerExpression> ret = new ArrayList<IntegerExpression>();
-    if (constant.signum() != 0) ret.add(new IValue(constant));
+    if (constant.signum() != 0) {
+      ret.add(new IValue(constant));
+    }
     for (Map.Entry<IntegerExpression,BigInteger> entry : counts.entrySet()) {
       BigInteger k = entry.getValue();
-      if (k.equals(BigInteger.ONE)) ret.add(entry.getKey());
-      else if (k.signum() != 0) ret.add(new CMult(k, entry.getKey()));
+      if (k.equals(BigInteger.ONE)) {
+        ret.add(entry.getKey());
+      }
+      else if (k.signum() != 0) {
+        ret.add(new CMult(k, entry.getKey()));
+      }
     }
     // return the result
-    if (ret.size() == 0) return new IValue(BigInteger.ZERO);
+    if (ret.size() == 0) {
+      return new IValue(BigInteger.ZERO);
+    }
     if (ret.size() == 1) return ret.get(0);
     return new Addition(ret, true);
   }
 
   public IntegerExpression multiply(BigInteger constant) {
-    if (constant.signum() == 0) return new IValue(BigInteger.ZERO);
-    if (constant.equals(BigInteger.ONE)) return this;
+    if (constant.signum() == 0) {
+      return new IValue(BigInteger.ZERO);
+    }
+    if (constant.equals(BigInteger.ONE)) {
+      return this;
+    }
     ArrayList<IntegerExpression> cs = new ArrayList<IntegerExpression>();
     for (int i = 0; i < _children.size(); i++) cs.add(_children.get(i).multiply(constant));
     return new Addition(cs, _simplified);

--- a/app/src/main/java/charlie/smt/CMult.java
+++ b/app/src/main/java/charlie/smt/CMult.java
@@ -50,23 +50,39 @@ public final class CMult extends IntegerExpression {
 
   public IntegerExpression simplify() {
     if (_simplified) return this;
-    if (_constant.signum() == 0) return new IValue(BigInteger.ZERO);
-    if (_constant.equals(BigInteger.ONE)) return _main.simplify();
+    if (_constant.signum() == 0) {
+      return new IValue(BigInteger.ZERO);
+    }
+    if (_constant.equals(BigInteger.ONE)) {
+      return _main.simplify();
+    }
     return _main.simplify().multiply(_constant);
   }
 
   public IntegerExpression multiply(BigInteger constant) {
     BigInteger newconstant = _constant.multiply(constant);
-    if (newconstant.signum() == 0) return new IValue(BigInteger.ZERO);
-    if (newconstant.equals(BigInteger.ONE)) return _main;
-    if (constant.equals(BigInteger.ONE)) return this;
+    if (newconstant.signum() == 0) {
+      return new IValue(BigInteger.ZERO);
+    }
+    if (newconstant.equals(BigInteger.ONE)) {
+      return _main;
+    }
+    if (constant.equals(BigInteger.ONE)) {
+      return this;
+    }
     return new CMult(newconstant, _main);
   }
 
   public void addToSmtString(StringBuilder builder) {
-    if (_constant.equals(BigInteger.valueOf(-1))) builder.append("(- ");
-    else if (_constant.signum() < 0) builder.append("(* (- " + _constant.negate() + ") ");
-    else builder.append("(* " + _constant + " ");
+    if (_constant.equals(BigInteger.valueOf(-1))) {
+      builder.append("(- ");
+    }
+    else if (_constant.signum() < 0) {
+      builder.append("(* (- " + _constant.negate() + ") ");
+    }
+    else {
+      builder.append("(* " + _constant + " ");
+    }
     _main.addToSmtString(builder);
     builder.append(")");
   }
@@ -77,7 +93,9 @@ public final class CMult extends IntegerExpression {
       case CMult cm -> {
         int c = _main.compareTo(cm.queryChild());
         if (c != 0) yield c;
-        else yield _constant.compareTo(cm.queryConstant());
+        else {
+          yield _constant.compareTo(cm.queryConstant());
+        }
       }
       default -> _main.compareTo(other) >= 0 ? 1 : -1;
     };

--- a/app/src/main/java/charlie/smt/CMult.java
+++ b/app/src/main/java/charlie/smt/CMult.java
@@ -50,39 +50,23 @@ public final class CMult extends IntegerExpression {
 
   public IntegerExpression simplify() {
     if (_simplified) return this;
-    if (_constant.signum() == 0) {
-      return new IValue(BigInteger.ZERO);
-    }
-    if (_constant.equals(BigInteger.ONE)) {
-      return _main.simplify();
-    }
+    if (_constant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (_constant.equals(BigInteger.ONE)) return _main.simplify();
     return _main.simplify().multiply(_constant);
   }
 
   public IntegerExpression multiply(BigInteger constant) {
     BigInteger newconstant = _constant.multiply(constant);
-    if (newconstant.signum() == 0) {
-      return new IValue(BigInteger.ZERO);
-    }
-    if (newconstant.equals(BigInteger.ONE)) {
-      return _main;
-    }
-    if (constant.equals(BigInteger.ONE)) {
-      return this;
-    }
+    if (newconstant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (newconstant.equals(BigInteger.ONE)) return _main;
+    if (constant.equals(BigInteger.ONE)) return this;
     return new CMult(newconstant, _main);
   }
 
   public void addToSmtString(StringBuilder builder) {
-    if (_constant.equals(BigInteger.valueOf(-1))) {
-      builder.append("(- ");
-    }
-    else if (_constant.signum() < 0) {
-      builder.append("(* (- " + _constant.negate() + ") ");
-    }
-    else {
-      builder.append("(* " + _constant + " ");
-    }
+    if (_constant.equals(BigInteger.valueOf(-1))) builder.append("(- ");
+    else if (_constant.signum() < 0) builder.append("(* (- " + _constant.negate() + ") ");
+    else builder.append("(* " + _constant + " ");
     _main.addToSmtString(builder);
     builder.append(")");
   }
@@ -93,9 +77,7 @@ public final class CMult extends IntegerExpression {
       case CMult cm -> {
         int c = _main.compareTo(cm.queryChild());
         if (c != 0) yield c;
-        else {
-          yield _constant.compareTo(cm.queryConstant());
-        }
+        else yield _constant.compareTo(cm.queryConstant());
       }
       default -> _main.compareTo(other) >= 0 ? 1 : -1;
     };

--- a/app/src/main/java/charlie/smt/CMult.java
+++ b/app/src/main/java/charlie/smt/CMult.java
@@ -15,21 +15,28 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 /** A multiplication by a constant */
 public final class CMult extends IntegerExpression {
-  private int _constant;
+  private BigInteger _constant;
   private IntegerExpression _main;
 
   /** The constructor is hidden, since IntegerExpressions should be made through the SmtFactory. */
-  CMult(int k, IntegerExpression e) {
+  CMult(BigInteger k, IntegerExpression e) {
     _constant = k;
     _main = e;
     if (_main.isSimplified() && !(_main instanceof IValue) &&
         !(_main instanceof CMult) && !(_main instanceof Addition) &&
-        _constant != 0 && _constant != 1) _simplified = true;
+        _constant.signum() != 0 && !_constant.equals(BigInteger.ONE)) _simplified = true;
   }
 
-  public int queryConstant() {
+  /** Convenience constructor for a small (Java int) constant. */
+  CMult(int k, IntegerExpression e) {
+    this(BigInteger.valueOf(k), e);
+  }
+
+  public BigInteger queryConstant() {
     return _constant;
   }
 
@@ -37,28 +44,28 @@ public final class CMult extends IntegerExpression {
     return _main;
   }
 
-  public int evaluate(Valuation val) {
-    return _constant * _main.evaluate(val);
+  public BigInteger evaluate(Valuation val) {
+    return _constant.multiply(_main.evaluate(val));
   }
 
   public IntegerExpression simplify() {
     if (_simplified) return this;
-    if (_constant == 0) return new IValue(0);
-    if (_constant == 1) return _main.simplify();
+    if (_constant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (_constant.equals(BigInteger.ONE)) return _main.simplify();
     return _main.simplify().multiply(_constant);
   }
 
-  public IntegerExpression multiply(int constant) {
-    int newconstant = _constant * constant;
-    if (newconstant == 0) return new IValue(0);
-    if (newconstant == 1) return _main;
-    if (constant == 1) return this;
+  public IntegerExpression multiply(BigInteger constant) {
+    BigInteger newconstant = _constant.multiply(constant);
+    if (newconstant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (newconstant.equals(BigInteger.ONE)) return _main;
+    if (constant.equals(BigInteger.ONE)) return this;
     return new CMult(newconstant, _main);
   }
 
   public void addToSmtString(StringBuilder builder) {
-    if (_constant == -1) builder.append("(- ");
-    else if (_constant < 0) builder.append("(* (- " + (-_constant) + ") ");
+    if (_constant.equals(BigInteger.valueOf(-1))) builder.append("(- ");
+    else if (_constant.signum() < 0) builder.append("(* (- " + _constant.negate() + ") ");
     else builder.append("(* " + _constant + " ");
     _main.addToSmtString(builder);
     builder.append(")");
@@ -70,14 +77,14 @@ public final class CMult extends IntegerExpression {
       case CMult cm -> {
         int c = _main.compareTo(cm.queryChild());
         if (c != 0) yield c;
-        else yield _constant - cm.queryConstant();
+        else yield _constant.compareTo(cm.queryConstant());
       }
       default -> _main.compareTo(other) >= 0 ? 1 : -1;
     };
   }
 
   public int hashCode() {
-    return 2 + 7 * (_main.hashCode() * 5 + _constant);
+    return 2 + 7 * (_main.hashCode() * 5 + _constant.hashCode());
   }
 }
 

--- a/app/src/main/java/charlie/smt/Comparison.java
+++ b/app/src/main/java/charlie/smt/Comparison.java
@@ -74,9 +74,7 @@ abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
   public Constraint simplify() {
     if (_simplified) return this;
     IntegerExpression e = _expr;
-    if (e instanceof CMult c && c.queryConstant().signum() != 0) {
-      e = c.queryChild();
-    }
+    if (e instanceof CMult c && c.queryConstant().signum() != 0) e = c.queryChild();
     if (e instanceof Multiplication m) return simplifyMultiplication(m);
     e = e.simplify();
     if (e instanceof CMult c) e = c.queryChild();
@@ -90,12 +88,8 @@ abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
       if (k.remainder(c.queryConstant()).signum() == 0) {
         e = c.queryChild().add(k.divide(c.queryConstant()));
       }
-      else if (this instanceof Is0) {
-        return new Falsehood();
-      }
-      else {
-        return new Truth();
-      }
+      else if (this instanceof Is0) return new Falsehood();
+      else return new Truth();
     }
     if (this instanceof Is0) return new Is0(e);
     else return new Neq0(e);

--- a/app/src/main/java/charlie/smt/Comparison.java
+++ b/app/src/main/java/charlie/smt/Comparison.java
@@ -74,7 +74,9 @@ abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
   public Constraint simplify() {
     if (_simplified) return this;
     IntegerExpression e = _expr;
-    if (e instanceof CMult c && c.queryConstant().signum() != 0) e = c.queryChild();
+    if (e instanceof CMult c && c.queryConstant().signum() != 0) {
+      e = c.queryChild();
+    }
     if (e instanceof Multiplication m) return simplifyMultiplication(m);
     e = e.simplify();
     if (e instanceof CMult c) e = c.queryChild();
@@ -88,8 +90,12 @@ abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
       if (k.remainder(c.queryConstant()).signum() == 0) {
         e = c.queryChild().add(k.divide(c.queryConstant()));
       }
-      else if (this instanceof Is0) return new Falsehood();
-      else return new Truth();
+      else if (this instanceof Is0) {
+        return new Falsehood();
+      }
+      else {
+        return new Truth();
+      }
     }
     if (this instanceof Is0) return new Is0(e);
     else return new Neq0(e);

--- a/app/src/main/java/charlie/smt/Comparison.java
+++ b/app/src/main/java/charlie/smt/Comparison.java
@@ -17,13 +17,14 @@ package charlie.smt;
 
 import charlie.util.Pair;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 
 /** Not a public class on purpose: use Constraint, or use Geq0, Is0 or Neq0 directly. */
 abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
   protected IntegerExpression _expr;
 
-  protected abstract boolean evaluate(int num);
+  protected abstract boolean evaluate(BigInteger num);
   protected abstract String symbol();
   public abstract Constraint negate();
 
@@ -57,7 +58,7 @@ abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
       case Multiplication m -> false;
       case Addition a -> {
         if (a.queryChild(a.numChildren()) instanceof CMult c) {
-          yield c.queryConstant() > 0 &&
+          yield c.queryConstant().signum() > 0 &&
                 (a.numChildren() > 2 || !(a.queryChild(1) instanceof IValue));
         }
         else yield true;
@@ -73,18 +74,20 @@ abstract sealed class Comparison extends Constraint permits Geq0, Is0, Neq0 {
   public Constraint simplify() {
     if (_simplified) return this;
     IntegerExpression e = _expr;
-    if (e instanceof CMult c && c.queryConstant() != 0) e = c.queryChild();
+    if (e instanceof CMult c && c.queryConstant().signum() != 0) e = c.queryChild();
     if (e instanceof Multiplication m) return simplifyMultiplication(m);
     e = e.simplify();
     if (e instanceof CMult c) e = c.queryChild();
     if (e instanceof Multiplication m) return simplifyMultiplication(m);
     if (e instanceof IValue v) return (evaluate(v.queryValue())) ? new Truth() : new Falsehood();
     if (e instanceof Addition a && a.queryChild(a.numChildren()) instanceof CMult c &&
-        c.queryConstant() < 0) e = e.negate();
+        c.queryConstant().signum() < 0) e = e.negate();
     if (e instanceof Addition a && a.queryChild(a.numChildren()) instanceof CMult c &&
         a.numChildren() == 2 && a.queryChild(1) instanceof IValue i) {
-      int k = i.queryValue();
-      if (k % c.queryConstant() == 0) e = c.queryChild().add(k / c.queryConstant());
+      BigInteger k = i.queryValue();
+      if (k.remainder(c.queryConstant()).signum() == 0) {
+        e = c.queryChild().add(k.divide(c.queryConstant()));
+      }
       else if (this instanceof Is0) return new Falsehood();
       else return new Truth();
     }

--- a/app/src/main/java/charlie/smt/Division.java
+++ b/app/src/main/java/charlie/smt/Division.java
@@ -15,6 +15,8 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class Division extends IntegerExpression {
   private IntegerExpression _numerator;
   private IntegerExpression _denominator;
@@ -39,18 +41,19 @@ public final class Division extends IntegerExpression {
    * that is: a / b following the SMTLIB standard (this is *not* the same as what _numerator /
    * _denominator returns in Java when negative values are concerned.
    */
-  public int evaluate(Valuation val) {
+  public BigInteger evaluate(Valuation val) {
     return evaluateFor(_numerator.evaluate(val), _denominator.evaluate(val));
   }
 
-  private static int evaluateFor(int n, int d) {
-    if (d == 0) return 0; // let's just make dividing by 0 return 0
-    int sign = (n >= 0 && d >= 0) || (n < 0 && d < 0) ? 1 : -1;
-    int abs_n = n >= 0 ? n : - n;
-    int abs_d = d >= 0 ? d : - d;
-    if (n >= 0) return sign * (abs_n / abs_d);
-    else if (abs_n % abs_d == 0) return sign * (abs_n / abs_d);
-    else return sign * (abs_n / abs_d + 1);
+  private static BigInteger evaluateFor(BigInteger n, BigInteger d) {
+    if (d.signum() == 0) return BigInteger.ZERO; // let's just make dividing by 0 return 0
+    BigInteger sign = (n.signum() >= 0 && d.signum() >= 0) || (n.signum() < 0 && d.signum() < 0)
+                      ? BigInteger.ONE : BigInteger.valueOf(-1);
+    BigInteger abs_n = n.abs();
+    BigInteger abs_d = d.abs();
+    if (n.signum() >= 0) return sign.multiply(abs_n.divide(abs_d));
+    else if (abs_n.remainder(abs_d).signum() == 0) return sign.multiply(abs_n.divide(abs_d));
+    else return sign.multiply(abs_n.divide(abs_d).add(BigInteger.ONE));
   }
 
   /**
@@ -61,11 +64,11 @@ public final class Division extends IntegerExpression {
     if (_numerator instanceof IValue && _denominator instanceof IValue) return;
     if (!_numerator.isSimplified() || !_denominator.isSimplified()) return;
     if (_denominator instanceof IValue k) {
-      _simplified = k.queryValue() != 1 && k.queryValue() >= 0;
-    }   
+      _simplified = !k.queryValue().equals(BigInteger.ONE) && k.queryValue().signum() >= 0;
+    }
     else if (_denominator instanceof CMult cm) {
-      _simplified = cm.queryConstant() >= 2;
-    }   
+      _simplified = cm.queryConstant().compareTo(BigInteger.TWO) >= 0;
+    }
     else _simplified = true;
   }
 
@@ -76,15 +79,15 @@ public final class Division extends IntegerExpression {
     switch (_denominator) {
       case IValue k:
         if (n instanceof IValue i) return new IValue(evaluateFor(i.queryValue(), k.queryValue()));
-        if (k.queryValue() == 1) return _numerator;
-        if (k.queryValue() == -1) return _numerator.multiply(-1); // a div -1 = -a
-        if (k.queryValue() < 0) { // a div -b = - (a div b)
+        if (k.queryValue().equals(BigInteger.ONE)) return _numerator;
+        if (k.queryValue().equals(BigInteger.valueOf(-1))) return _numerator.multiply(-1); // a div -1 = -a
+        if (k.queryValue().signum() < 0) { // a div -b = - (a div b)
           IntegerExpression ret = new CMult(-1, new Division(n, k.multiply(-1)));
           return ret.simplify();
         }
         return new Division(n, d);
       case CMult cm:
-        if (cm.queryConstant() < 0) {
+        if (cm.queryConstant().signum() < 0) {
           IntegerExpression ret = new CMult(-1, new Division(n, cm.multiply(-1)));
           return ret.simplify();
         }

--- a/app/src/main/java/charlie/smt/Division.java
+++ b/app/src/main/java/charlie/smt/Division.java
@@ -51,15 +51,9 @@ public final class Division extends IntegerExpression {
                       ? BigInteger.ONE : BigInteger.valueOf(-1);
     BigInteger abs_n = n.abs();
     BigInteger abs_d = d.abs();
-    if (n.signum() >= 0) {
-      return sign.multiply(abs_n.divide(abs_d));
-    }
-    else if (abs_n.remainder(abs_d).signum() == 0) {
-      return sign.multiply(abs_n.divide(abs_d));
-    }
-    else {
-      return sign.multiply(abs_n.divide(abs_d).add(BigInteger.ONE));
-    }
+    if (n.signum() >= 0) return sign.multiply(abs_n.divide(abs_d));
+    else if (abs_n.remainder(abs_d).signum() == 0) return sign.multiply(abs_n.divide(abs_d));
+    else return sign.multiply(abs_n.divide(abs_d).add(BigInteger.ONE));
   }
 
   /**
@@ -85,13 +79,8 @@ public final class Division extends IntegerExpression {
     switch (_denominator) {
       case IValue k:
         if (n instanceof IValue i) return new IValue(evaluateFor(i.queryValue(), k.queryValue()));
-        if (k.queryValue().equals(BigInteger.ONE)) {
-          return _numerator;
-        }
-        // a div -1 = -a
-        if (k.queryValue().equals(BigInteger.valueOf(-1))) {
-          return _numerator.multiply(-1);
-        }
+        if (k.queryValue().equals(BigInteger.ONE)) return _numerator;
+        if (k.queryValue().equals(BigInteger.valueOf(-1))) return _numerator.multiply(-1); // a div -1 = -a
         if (k.queryValue().signum() < 0) { // a div -b = - (a div b)
           IntegerExpression ret = new CMult(-1, new Division(n, k.multiply(-1)));
           return ret.simplify();

--- a/app/src/main/java/charlie/smt/Division.java
+++ b/app/src/main/java/charlie/smt/Division.java
@@ -51,9 +51,15 @@ public final class Division extends IntegerExpression {
                       ? BigInteger.ONE : BigInteger.valueOf(-1);
     BigInteger abs_n = n.abs();
     BigInteger abs_d = d.abs();
-    if (n.signum() >= 0) return sign.multiply(abs_n.divide(abs_d));
-    else if (abs_n.remainder(abs_d).signum() == 0) return sign.multiply(abs_n.divide(abs_d));
-    else return sign.multiply(abs_n.divide(abs_d).add(BigInteger.ONE));
+    if (n.signum() >= 0) {
+      return sign.multiply(abs_n.divide(abs_d));
+    }
+    else if (abs_n.remainder(abs_d).signum() == 0) {
+      return sign.multiply(abs_n.divide(abs_d));
+    }
+    else {
+      return sign.multiply(abs_n.divide(abs_d).add(BigInteger.ONE));
+    }
   }
 
   /**
@@ -79,8 +85,13 @@ public final class Division extends IntegerExpression {
     switch (_denominator) {
       case IValue k:
         if (n instanceof IValue i) return new IValue(evaluateFor(i.queryValue(), k.queryValue()));
-        if (k.queryValue().equals(BigInteger.ONE)) return _numerator;
-        if (k.queryValue().equals(BigInteger.valueOf(-1))) return _numerator.multiply(-1); // a div -1 = -a
+        if (k.queryValue().equals(BigInteger.ONE)) {
+          return _numerator;
+        }
+        // a div -1 = -a
+        if (k.queryValue().equals(BigInteger.valueOf(-1))) {
+          return _numerator.multiply(-1);
+        }
         if (k.queryValue().signum() < 0) { // a div -b = - (a div b)
           IntegerExpression ret = new CMult(-1, new Division(n, k.multiply(-1)));
           return ret.simplify();

--- a/app/src/main/java/charlie/smt/Geq0.java
+++ b/app/src/main/java/charlie/smt/Geq0.java
@@ -15,10 +15,12 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class Geq0 extends Comparison {
   Geq0(IntegerExpression expr) { super(expr); }
   Geq0(IntegerExpression left, IntegerExpression right) { super(left, right); }
-  protected boolean evaluate(int num) { return num >= 0; }
+  protected boolean evaluate(BigInteger num) { return num.signum() >= 0; }
   protected String symbol() { return ">="; }
   public int hashCode() { return 17 * _expr.hashCode() + 4; }
 
@@ -30,11 +32,11 @@ public final class Geq0 extends Comparison {
 
   protected boolean checkSimplified() {
     if (!_expr.isSimplified() || _expr instanceof IValue) return false;
-    if (_expr instanceof CMult c) { return c.queryConstant() == -1; }
+    if (_expr instanceof CMult c) { return c.queryConstant().equals(BigInteger.valueOf(-1)); }
     if (_expr instanceof Addition a &&
         a.queryChild(a.numChildren()) instanceof CMult c &&
         a.numChildren() == 2 && a.queryChild(1) instanceof IValue) {
-      return c.queryConstant() == -1;
+      return c.queryConstant().equals(BigInteger.valueOf(-1));
     }
     return true;
   }
@@ -44,21 +46,23 @@ public final class Geq0 extends Comparison {
     // we apply removeCMult both before and after simplifying, because the simplify step might
     // destroy an earlier CMult (or create one from a more complex expression)
     IntegerExpression e = removeCMult(removeCMult(_expr).simplify());
-    if (e instanceof IValue v) { return v.queryValue() >= 0 ? new Truth() : new Falsehood(); }
+    if (e instanceof IValue v) { return v.queryValue().signum() >= 0 ? new Truth() : new Falsehood(); }
     if (e instanceof Addition ad && ad.numChildren() == 2 && ad.queryChild(1) instanceof IValue k &&
-        ad.queryChild(2) instanceof CMult c && c.queryConstant() != -1) {
-      int a = c.queryConstant();
-      int b = k.queryValue();
-      if (a > 1) {
+        ad.queryChild(2) instanceof CMult c && !c.queryConstant().equals(BigInteger.valueOf(-1))) {
+      BigInteger a = c.queryConstant();
+      BigInteger b = k.queryValue();
+      if (a.compareTo(BigInteger.ONE) > 0) {
         // a x ≥ -b <==> x ≥ CEIL(-b/a)
-        int v = b < 0 ? -((-b + a - 1) / a) : b / a;
-        if (v == 0) e = c.queryChild();
+        BigInteger v = b.signum() < 0 ? b.negate().add(a).subtract(BigInteger.ONE).divide(a).negate()
+                                      : b.divide(a);
+        if (v.signum() == 0) e = c.queryChild();
         else e = new Addition(new IValue(v), c.queryChild());
       }
       else {  // a < -1
         // b ≥ -a x <==> x ≤ FLOOR(b/-a)
-        int v = b > 0 ? b / -a : -((-b - a - 1) / -a);
-        if (v == 0) e = new CMult(-1, c.queryChild());
+        BigInteger v = b.signum() > 0 ? b.divide(a.negate())
+                       : b.negate().subtract(a).subtract(BigInteger.ONE).divide(a.negate()).negate();
+        if (v.signum() == 0) e = new CMult(-1, c.queryChild());
         else e = new Addition(new IValue(v), new CMult(-1, c.queryChild()));
       }
     }
@@ -68,9 +72,9 @@ public final class Geq0 extends Comparison {
   /** Helper function for simplify: removes a CMult taking signs into account. */
   protected IntegerExpression removeCMult(IntegerExpression e) {
     if (e instanceof CMult c) {
-      int k = c.queryConstant();
-      if (k > 0) return c.queryChild();
-      if (k < -1) return new CMult(-1, c.queryChild());
+      BigInteger k = c.queryConstant();
+      if (k.signum() > 0) return c.queryChild();
+      if (k.compareTo(BigInteger.valueOf(-1)) < 0) return new CMult(-1, c.queryChild());
     }
     return e;
   }

--- a/app/src/main/java/charlie/smt/Geq0.java
+++ b/app/src/main/java/charlie/smt/Geq0.java
@@ -46,36 +46,24 @@ public final class Geq0 extends Comparison {
     // we apply removeCMult both before and after simplifying, because the simplify step might
     // destroy an earlier CMult (or create one from a more complex expression)
     IntegerExpression e = removeCMult(removeCMult(_expr).simplify());
-    if (e instanceof IValue v) {
-      return v.queryValue().signum() >= 0 ? new Truth() : new Falsehood();
-    }
+    if (e instanceof IValue v) { return v.queryValue().signum() >= 0 ? new Truth() : new Falsehood(); }
     if (e instanceof Addition ad && ad.numChildren() == 2 && ad.queryChild(1) instanceof IValue k &&
         ad.queryChild(2) instanceof CMult c && !c.queryConstant().equals(BigInteger.valueOf(-1))) {
       BigInteger a = c.queryConstant();
       BigInteger b = k.queryValue();
       if (a.compareTo(BigInteger.ONE) > 0) {
         // a x ≥ -b <==> x ≥ CEIL(-b/a)
-        BigInteger v = b.signum() < 0
-          ? b.negate().add(a).subtract(BigInteger.ONE).divide(a).negate()
-          : b.divide(a);
-        if (v.signum() == 0) {
-          e = c.queryChild();
-        }
-        else {
-          e = new Addition(new IValue(v), c.queryChild());
-        }
+        BigInteger v = b.signum() < 0 ? b.negate().add(a).subtract(BigInteger.ONE).divide(a).negate()
+                                      : b.divide(a);
+        if (v.signum() == 0) e = c.queryChild();
+        else e = new Addition(new IValue(v), c.queryChild());
       }
       else {  // a < -1
         // b ≥ -a x <==> x ≤ FLOOR(b/-a)
-        BigInteger v = b.signum() > 0
-          ? b.divide(a.negate())
-          : b.negate().subtract(a).subtract(BigInteger.ONE).divide(a.negate()).negate();
-        if (v.signum() == 0) {
-          e = new CMult(-1, c.queryChild());
-        }
-        else {
-          e = new Addition(new IValue(v), new CMult(-1, c.queryChild()));
-        }
+        BigInteger v = b.signum() > 0 ? b.divide(a.negate())
+                       : b.negate().subtract(a).subtract(BigInteger.ONE).divide(a.negate()).negate();
+        if (v.signum() == 0) e = new CMult(-1, c.queryChild());
+        else e = new Addition(new IValue(v), new CMult(-1, c.queryChild()));
       }
     }
     return new Geq0(e);
@@ -85,12 +73,8 @@ public final class Geq0 extends Comparison {
   protected IntegerExpression removeCMult(IntegerExpression e) {
     if (e instanceof CMult c) {
       BigInteger k = c.queryConstant();
-      if (k.signum() > 0) {
-        return c.queryChild();
-      }
-      if (k.compareTo(BigInteger.valueOf(-1)) < 0) {
-        return new CMult(-1, c.queryChild());
-      }
+      if (k.signum() > 0) return c.queryChild();
+      if (k.compareTo(BigInteger.valueOf(-1)) < 0) return new CMult(-1, c.queryChild());
     }
     return e;
   }

--- a/app/src/main/java/charlie/smt/Geq0.java
+++ b/app/src/main/java/charlie/smt/Geq0.java
@@ -46,24 +46,36 @@ public final class Geq0 extends Comparison {
     // we apply removeCMult both before and after simplifying, because the simplify step might
     // destroy an earlier CMult (or create one from a more complex expression)
     IntegerExpression e = removeCMult(removeCMult(_expr).simplify());
-    if (e instanceof IValue v) { return v.queryValue().signum() >= 0 ? new Truth() : new Falsehood(); }
+    if (e instanceof IValue v) {
+      return v.queryValue().signum() >= 0 ? new Truth() : new Falsehood();
+    }
     if (e instanceof Addition ad && ad.numChildren() == 2 && ad.queryChild(1) instanceof IValue k &&
         ad.queryChild(2) instanceof CMult c && !c.queryConstant().equals(BigInteger.valueOf(-1))) {
       BigInteger a = c.queryConstant();
       BigInteger b = k.queryValue();
       if (a.compareTo(BigInteger.ONE) > 0) {
         // a x ≥ -b <==> x ≥ CEIL(-b/a)
-        BigInteger v = b.signum() < 0 ? b.negate().add(a).subtract(BigInteger.ONE).divide(a).negate()
-                                      : b.divide(a);
-        if (v.signum() == 0) e = c.queryChild();
-        else e = new Addition(new IValue(v), c.queryChild());
+        BigInteger v = b.signum() < 0
+          ? b.negate().add(a).subtract(BigInteger.ONE).divide(a).negate()
+          : b.divide(a);
+        if (v.signum() == 0) {
+          e = c.queryChild();
+        }
+        else {
+          e = new Addition(new IValue(v), c.queryChild());
+        }
       }
       else {  // a < -1
         // b ≥ -a x <==> x ≤ FLOOR(b/-a)
-        BigInteger v = b.signum() > 0 ? b.divide(a.negate())
-                       : b.negate().subtract(a).subtract(BigInteger.ONE).divide(a.negate()).negate();
-        if (v.signum() == 0) e = new CMult(-1, c.queryChild());
-        else e = new Addition(new IValue(v), new CMult(-1, c.queryChild()));
+        BigInteger v = b.signum() > 0
+          ? b.divide(a.negate())
+          : b.negate().subtract(a).subtract(BigInteger.ONE).divide(a.negate()).negate();
+        if (v.signum() == 0) {
+          e = new CMult(-1, c.queryChild());
+        }
+        else {
+          e = new Addition(new IValue(v), new CMult(-1, c.queryChild()));
+        }
       }
     }
     return new Geq0(e);
@@ -73,8 +85,12 @@ public final class Geq0 extends Comparison {
   protected IntegerExpression removeCMult(IntegerExpression e) {
     if (e instanceof CMult c) {
       BigInteger k = c.queryConstant();
-      if (k.signum() > 0) return c.queryChild();
-      if (k.compareTo(BigInteger.valueOf(-1)) < 0) return new CMult(-1, c.queryChild());
+      if (k.signum() > 0) {
+        return c.queryChild();
+      }
+      if (k.compareTo(BigInteger.valueOf(-1)) < 0) {
+        return new CMult(-1, c.queryChild());
+      }
     }
     return e;
   }

--- a/app/src/main/java/charlie/smt/IExpPrinter.java
+++ b/app/src/main/java/charlie/smt/IExpPrinter.java
@@ -15,6 +15,8 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 /**
  * IExpPrinters are used in the overall output process of the tool.  This class provides a default
  * implementation, but is meant to be inherited.  You can for instance instantiate the IExpPrinter
@@ -126,7 +128,7 @@ public class IExpPrinter {
    * neither basic nor a multiplication.
    */
   protected void printCMult(CMult c, StringBuilder builder) {
-    if (c.queryConstant() == -1) {
+    if (c.queryConstant().equals(BigInteger.valueOf(-1))) {
       builder.append("-");
       if (c.queryChild() instanceof IVar x) printVar(x, builder);
       else {

--- a/app/src/main/java/charlie/smt/IValue.java
+++ b/app/src/main/java/charlie/smt/IValue.java
@@ -52,8 +52,12 @@ public final class IValue extends IntegerExpression {
   }
 
   public void addToSmtString(StringBuilder builder) {
-    if (_k.signum() >= 0) builder.append(_k.toString());
-    else builder.append("(- " + _k.negate() + ")");
+    if (_k.signum() >= 0) {
+      builder.append(_k.toString());
+    }
+    else {
+      builder.append("(- " + _k.negate() + ")");
+    }
   }
 
   public int compareTo(IntegerExpression other) {

--- a/app/src/main/java/charlie/smt/IValue.java
+++ b/app/src/main/java/charlie/smt/IValue.java
@@ -15,20 +15,27 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class IValue extends IntegerExpression {
-  private int _k;
+  private BigInteger _k;
 
   /** The constructor is hidden, since IntegerExpressions should be made through the SmtFactory. */
-  IValue(int i) {
+  IValue(BigInteger i) {
     _k = i;
     _simplified = true;
   }
 
-  public int queryValue() {
+  /** Convenience constructor for a small (Java int) value. */
+  IValue(int i) {
+    this(BigInteger.valueOf(i));
+  }
+
+  public BigInteger queryValue() {
     return _k;
   }
 
-  public int evaluate(Valuation val) {
+  public BigInteger evaluate(Valuation val) {
     return _k;
   }
 
@@ -36,28 +43,28 @@ public final class IValue extends IntegerExpression {
     return this;
   }
 
-  public IntegerExpression add(int value) {
-    return new IValue(value + _k);
+  public IntegerExpression add(BigInteger value) {
+    return new IValue(value.add(_k));
   }
 
-  public IntegerExpression multiply(int value) {
-    return new IValue(value * _k);
+  public IntegerExpression multiply(BigInteger value) {
+    return new IValue(value.multiply(_k));
   }
 
   public void addToSmtString(StringBuilder builder) {
-    if (_k >= 0) builder.append("" + _k);
-    else builder.append("(- " + (-_k) + ")");
+    if (_k.signum() >= 0) builder.append(_k.toString());
+    else builder.append("(- " + _k.negate() + ")");
   }
 
   public int compareTo(IntegerExpression other) {
     return switch (other) {
-      case IValue v -> _k - v.queryValue();
+      case IValue v -> _k.compareTo(v.queryValue());
       default -> -1;
     };
   }
 
   public int hashCode() {
-    return 7 * _k;
+    return 7 * _k.hashCode();
   }
 }
 

--- a/app/src/main/java/charlie/smt/IValue.java
+++ b/app/src/main/java/charlie/smt/IValue.java
@@ -52,12 +52,8 @@ public final class IValue extends IntegerExpression {
   }
 
   public void addToSmtString(StringBuilder builder) {
-    if (_k.signum() >= 0) {
-      builder.append(_k.toString());
-    }
-    else {
-      builder.append("(- " + _k.negate() + ")");
-    }
+    if (_k.signum() >= 0) builder.append(_k.toString());
+    else builder.append("(- " + _k.negate() + ")");
   }
 
   public int compareTo(IntegerExpression other) {

--- a/app/src/main/java/charlie/smt/IVar.java
+++ b/app/src/main/java/charlie/smt/IVar.java
@@ -15,6 +15,8 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class IVar extends IntegerExpression {
   private int _index;
   private String _name;
@@ -41,7 +43,7 @@ public final class IVar extends IntegerExpression {
     return _name;
   }
 
-  public int evaluate(Valuation val) {
+  public BigInteger evaluate(Valuation val) {
     if (val == null) throw new SmtEvaluationException(this);
     else return val.queryIntAssignment(_index);
   }

--- a/app/src/main/java/charlie/smt/IntegerExpression.java
+++ b/app/src/main/java/charlie/smt/IntegerExpression.java
@@ -87,9 +87,7 @@ public sealed abstract class IntegerExpression implements Comparable<IntegerExpr
    * expression.  If the current IntegerExpression is in simplifed form, then so is the result.
    */
   public IntegerExpression add(BigInteger constant) {
-    if (constant.signum() == 0) {
-      return this;
-    }
+    if (constant.signum() == 0) return this;
     return new Addition(new IValue(constant), this);
   }
 
@@ -103,12 +101,8 @@ public sealed abstract class IntegerExpression implements Comparable<IntegerExpr
    * constant.  If the current IntegerExpression is in simplified form, then so is the result.
    */
   public IntegerExpression multiply(BigInteger constant) {
-    if (constant.signum() == 0) {
-      return new IValue(BigInteger.ZERO);
-    }
-    if (constant.equals(BigInteger.ONE)) {
-      return this;
-    }
+    if (constant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (constant.equals(BigInteger.ONE)) return this;
     return new CMult(constant, this);
   }
 

--- a/app/src/main/java/charlie/smt/IntegerExpression.java
+++ b/app/src/main/java/charlie/smt/IntegerExpression.java
@@ -87,7 +87,9 @@ public sealed abstract class IntegerExpression implements Comparable<IntegerExpr
    * expression.  If the current IntegerExpression is in simplifed form, then so is the result.
    */
   public IntegerExpression add(BigInteger constant) {
-    if (constant.signum() == 0) return this;
+    if (constant.signum() == 0) {
+      return this;
+    }
     return new Addition(new IValue(constant), this);
   }
 
@@ -101,8 +103,12 @@ public sealed abstract class IntegerExpression implements Comparable<IntegerExpr
    * constant.  If the current IntegerExpression is in simplified form, then so is the result.
    */
   public IntegerExpression multiply(BigInteger constant) {
-    if (constant.signum() == 0) return new IValue(BigInteger.ZERO);
-    if (constant.equals(BigInteger.ONE)) return this;
+    if (constant.signum() == 0) {
+      return new IValue(BigInteger.ZERO);
+    }
+    if (constant.equals(BigInteger.ONE)) {
+      return this;
+    }
     return new CMult(constant, this);
   }
 

--- a/app/src/main/java/charlie/smt/IntegerExpression.java
+++ b/app/src/main/java/charlie/smt/IntegerExpression.java
@@ -16,10 +16,11 @@
 package charlie.smt;
 
 import java.lang.Comparable;
+import java.math.BigInteger;
 
 /**
  * An IntegerExpression is an expression built from integer values, addition, multiplication, etc.:
- * the symbols in the integer theory, yielding an int.
+ * the symbols in the integer theory, yielding an (arbitrary-precision) integer.
  *
  * IntegerExpressions can be expected to be immutable.
  */
@@ -45,7 +46,7 @@ public sealed abstract class IntegerExpression implements Comparable<IntegerExpr
    * This evaluates the current expression, taking the values for all variables from the given
    * valuation.
    */
-  public abstract int evaluate(Valuation val);
+  public abstract BigInteger evaluate(Valuation val);
 
   /** Adds the SMT description of the current expression to the given string builder. */
   public abstract void addToSmtString(StringBuilder builder);
@@ -85,33 +86,43 @@ public sealed abstract class IntegerExpression implements Comparable<IntegerExpr
    * This returns an integer expression obtained from adding the given constant to the current
    * expression.  If the current IntegerExpression is in simplifed form, then so is the result.
    */
-  public IntegerExpression add(int constant) {
-    if (constant == 0) return this;
+  public IntegerExpression add(BigInteger constant) {
+    if (constant.signum() == 0) return this;
     return new Addition(new IValue(constant), this);
+  }
+
+  /** Convenience overload of {@link #add(BigInteger)} for a small (Java int) constant. */
+  public final IntegerExpression add(int constant) {
+    return add(BigInteger.valueOf(constant));
   }
 
   /**
    * This returns an integer expression obtained from multiplying the current one by the given
    * constant.  If the current IntegerExpression is in simplified form, then so is the result.
    */
-  public IntegerExpression multiply(int constant) {
-    if (constant == 0) return new IValue(0);
-    if (constant == 1) return this;
+  public IntegerExpression multiply(BigInteger constant) {
+    if (constant.signum() == 0) return new IValue(BigInteger.ZERO);
+    if (constant.equals(BigInteger.ONE)) return this;
     return new CMult(constant, this);
+  }
+
+  /** Convenience overload of {@link #multiply(BigInteger)} for a small (Java int) constant. */
+  public final IntegerExpression multiply(int constant) {
+    return multiply(BigInteger.valueOf(constant));
   }
 
   /**
    * Assuming the current expression has no variables, this function evaluates it to its integer
    * value.  If there is a variable in it, an SmtEvaluationException will be thrown instead.
    */
-  public final int evaluate() { return evaluate(null); }
+  public final BigInteger evaluate() { return evaluate(null); }
 
   /**
    * This returns an integer expression obtained from multiplying the current one by -1.  If the
    * current IntegerExpression is in simplified form, then so is the result.
    */
   public final IntegerExpression negate() {
-    return multiply(-1);
+    return multiply(BigInteger.valueOf(-1));
   }
 
   public final String toString() {

--- a/app/src/main/java/charlie/smt/Is0.java
+++ b/app/src/main/java/charlie/smt/Is0.java
@@ -15,11 +15,13 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class Is0 extends Comparison {
   Is0(IntegerExpression expr) { super(expr); }
   Is0(IntegerExpression left, IntegerExpression right) { super(left, right); }
   public Neq0 negate() { return new Neq0(_expr); }
-  protected boolean evaluate(int num) { return num == 0; }
+  protected boolean evaluate(BigInteger num) { return num.signum() == 0; }
   protected String symbol() { return "="; }
   public int hashCode() { return 17 * _expr.hashCode() + 5; }
 }

--- a/app/src/main/java/charlie/smt/Modulo.java
+++ b/app/src/main/java/charlie/smt/Modulo.java
@@ -15,6 +15,8 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class Modulo extends IntegerExpression {
   private IntegerExpression _numerator;
   private IntegerExpression _denominator;
@@ -40,17 +42,17 @@ public final class Modulo extends IntegerExpression {
    * (this is *not* the same as what _numerator % _denominator returns in Java when negative
    * values are concerned).
    */
-  public int evaluate(Valuation val) {
+  public BigInteger evaluate(Valuation val) {
     return evaluateFor(_numerator.evaluate(val), _denominator.evaluate(val));
   }
 
-  private static int evaluateFor(int n, int d) {
-    if (d == 0) return 0; // let's just make dividing by 0 return 0
-    int abs_n = n >= 0 ? n : - n;
-    int abs_d = d >= 0 ? d : - d;
-    int ret = abs_n % abs_d;
-    if (n >= 0 || ret == 0) return ret;
-    return abs_d - ret;
+  private static BigInteger evaluateFor(BigInteger n, BigInteger d) {
+    if (d.signum() == 0) return BigInteger.ZERO; // let's just make dividing by 0 return 0
+    BigInteger abs_n = n.abs();
+    BigInteger abs_d = d.abs();
+    BigInteger ret = abs_n.remainder(abs_d);
+    if (n.signum() >= 0 || ret.signum() == 0) return ret;
+    return abs_d.subtract(ret);
   }
 
   /**
@@ -61,10 +63,10 @@ public final class Modulo extends IntegerExpression {
     if (_numerator instanceof IValue && _denominator instanceof IValue) return;
     if (!_numerator.isSimplified() || !_denominator.isSimplified()) return;
     if (_denominator instanceof IValue k) {
-      _simplified = k.queryValue() != 1 && k.queryValue() >= 0;
+      _simplified = !k.queryValue().equals(BigInteger.ONE) && k.queryValue().signum() >= 0;
     }
     else if (_denominator instanceof CMult cm) {
-      _simplified = cm.queryConstant() >= 2;
+      _simplified = cm.queryConstant().compareTo(BigInteger.TWO) >= 0;
     }
     else _simplified = true;
   }
@@ -76,13 +78,14 @@ public final class Modulo extends IntegerExpression {
     switch (_denominator) {
       case IValue k:
         if (n instanceof IValue i) return new IValue(evaluateFor(i.queryValue(), k.queryValue()));
-        if (k.queryValue() == 1 || k.queryValue() == -1) return new IValue(0);
-        if (k.queryValue() < 0) { // a mod -b = a mod b
+        if (k.queryValue().equals(BigInteger.ONE) || k.queryValue().equals(BigInteger.valueOf(-1)))
+          return new IValue(BigInteger.ZERO);
+        if (k.queryValue().signum() < 0) { // a mod -b = a mod b
           return new Modulo(n, k.multiply(-1));
         }
         return new Modulo(n, d);
       case CMult cm:
-        if (cm.queryConstant() < 0) {
+        if (cm.queryConstant().signum() < 0) {
           return new Modulo(n, cm.multiply(-1));
         }
       default:

--- a/app/src/main/java/charlie/smt/Modulo.java
+++ b/app/src/main/java/charlie/smt/Modulo.java
@@ -51,7 +51,9 @@ public final class Modulo extends IntegerExpression {
     BigInteger abs_n = n.abs();
     BigInteger abs_d = d.abs();
     BigInteger ret = abs_n.remainder(abs_d);
-    if (n.signum() >= 0 || ret.signum() == 0) return ret;
+    if (n.signum() >= 0 || ret.signum() == 0) {
+      return ret;
+    }
     return abs_d.subtract(ret);
   }
 
@@ -78,8 +80,10 @@ public final class Modulo extends IntegerExpression {
     switch (_denominator) {
       case IValue k:
         if (n instanceof IValue i) return new IValue(evaluateFor(i.queryValue(), k.queryValue()));
-        if (k.queryValue().equals(BigInteger.ONE) || k.queryValue().equals(BigInteger.valueOf(-1)))
+        if (k.queryValue().equals(BigInteger.ONE) ||
+            k.queryValue().equals(BigInteger.valueOf(-1))) {
           return new IValue(BigInteger.ZERO);
+        }
         if (k.queryValue().signum() < 0) { // a mod -b = a mod b
           return new Modulo(n, k.multiply(-1));
         }

--- a/app/src/main/java/charlie/smt/Modulo.java
+++ b/app/src/main/java/charlie/smt/Modulo.java
@@ -51,9 +51,7 @@ public final class Modulo extends IntegerExpression {
     BigInteger abs_n = n.abs();
     BigInteger abs_d = d.abs();
     BigInteger ret = abs_n.remainder(abs_d);
-    if (n.signum() >= 0 || ret.signum() == 0) {
-      return ret;
-    }
+    if (n.signum() >= 0 || ret.signum() == 0) return ret;
     return abs_d.subtract(ret);
   }
 

--- a/app/src/main/java/charlie/smt/Multiplication.java
+++ b/app/src/main/java/charlie/smt/Multiplication.java
@@ -15,6 +15,7 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -63,9 +64,11 @@ public final class Multiplication extends IntegerExpression {
     return _children.get(index-1);
   }
 
-  public int evaluate(Valuation val) {
-    int ret = 1;
-    for (int i = 0; i < _children.size() && ret != 0; i++) ret *= _children.get(i).evaluate(val);
+  public BigInteger evaluate(Valuation val) {
+    BigInteger ret = BigInteger.ONE;
+    for (int i = 0; i < _children.size() && ret.signum() != 0; i++) {
+      ret = ret.multiply(_children.get(i).evaluate(val));
+    }
     return ret;
   }
 
@@ -90,18 +93,18 @@ public final class Multiplication extends IntegerExpression {
    * these are multiplied together and returned.  Multiplications in the simplifications of from
    * are expanded.
    */
-  private int addSimplifiedChildren(ArrayList<IntegerExpression> from,
-                                    ArrayList<IntegerExpression> to) {
-    int constant = 1;
+  private BigInteger addSimplifiedChildren(ArrayList<IntegerExpression> from,
+                                           ArrayList<IntegerExpression> to) {
+    BigInteger constant = BigInteger.ONE;
     for (IntegerExpression child : from) {
       IntegerExpression c = child.simplify();
-      if (c instanceof IValue k) constant *= k.queryValue();
+      if (c instanceof IValue k) constant = constant.multiply(k.queryValue());
       else if (c instanceof CMult cm) {
-        constant *= cm.queryConstant();
+        constant = constant.multiply(cm.queryConstant());
         to.add(cm.queryChild());
       }
       else if (c instanceof Multiplication m) {
-        constant *= addSimplifiedChildren(m._children, to);
+        constant = constant.multiply(addSimplifiedChildren(m._children, to));
       }
       else to.add(c);
     }
@@ -111,7 +114,7 @@ public final class Multiplication extends IntegerExpression {
   public IntegerExpression simplify() {
     if (_simplified) return this;
     ArrayList<IntegerExpression> todo = new ArrayList<IntegerExpression>();
-    int constant = addSimplifiedChildren(_children, todo);
+    BigInteger constant = addSimplifiedChildren(_children, todo);
     Collections.sort(todo);
     if (todo.size() == 0) return new IValue(constant);
     if (todo.size() == 1) return todo.get(0).multiply(constant);

--- a/app/src/main/java/charlie/smt/Multiplication.java
+++ b/app/src/main/java/charlie/smt/Multiplication.java
@@ -98,7 +98,9 @@ public final class Multiplication extends IntegerExpression {
     BigInteger constant = BigInteger.ONE;
     for (IntegerExpression child : from) {
       IntegerExpression c = child.simplify();
-      if (c instanceof IValue k) constant = constant.multiply(k.queryValue());
+      if (c instanceof IValue k) {
+        constant = constant.multiply(k.queryValue());
+      }
       else if (c instanceof CMult cm) {
         constant = constant.multiply(cm.queryConstant());
         to.add(cm.queryChild());

--- a/app/src/main/java/charlie/smt/Multiplication.java
+++ b/app/src/main/java/charlie/smt/Multiplication.java
@@ -98,9 +98,7 @@ public final class Multiplication extends IntegerExpression {
     BigInteger constant = BigInteger.ONE;
     for (IntegerExpression child : from) {
       IntegerExpression c = child.simplify();
-      if (c instanceof IValue k) {
-        constant = constant.multiply(k.queryValue());
-      }
+      if (c instanceof IValue k) constant = constant.multiply(k.queryValue());
       else if (c instanceof CMult cm) {
         constant = constant.multiply(cm.queryConstant());
         to.add(cm.queryChild());

--- a/app/src/main/java/charlie/smt/Neq0.java
+++ b/app/src/main/java/charlie/smt/Neq0.java
@@ -15,11 +15,13 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
+
 public final class Neq0 extends Comparison {
   Neq0(IntegerExpression expr) { super(expr); }
   Neq0(IntegerExpression left, IntegerExpression right) { super(left, right); }
   public Is0 negate() { return new Is0(_expr); }
-  protected boolean evaluate(int num) { return num != 0; }
+  protected boolean evaluate(BigInteger num) { return num.signum() != 0; }
   protected String symbol() { return "distinct"; }
   public int hashCode() { return 17 * _expr.hashCode() + 6; }
 }

--- a/app/src/main/java/charlie/smt/SmtFactory.java
+++ b/app/src/main/java/charlie/smt/SmtFactory.java
@@ -15,6 +15,7 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import charlie.util.NullStorageException;
@@ -49,6 +50,10 @@ public class SmtFactory {
   }
 
   public static IntegerExpression createValue(int v) {
+    return new IValue(v);
+  }
+
+  public static IntegerExpression createValue(BigInteger v) {
     return new IValue(v);
   }
   

--- a/app/src/main/java/charlie/smt/Valuation.java
+++ b/app/src/main/java/charlie/smt/Valuation.java
@@ -15,6 +15,7 @@
 
 package charlie.smt;
 
+import java.math.BigInteger;
 import java.util.TreeSet;
 import java.util.TreeMap;
 
@@ -25,13 +26,13 @@ import java.util.TreeMap;
  */
 public class Valuation {
   private TreeSet<Integer> _trueBVars;
-  private TreeMap<Integer,Integer> _iVarValues;
+  private TreeMap<Integer,BigInteger> _iVarValues;
   private TreeMap<Integer,String> _sVarValues;
 
   /** Creates a new valuation with all booleans set to false, and no integer/string values set. */
   public Valuation() {
     _trueBVars = new TreeSet<Integer>();
-    _iVarValues = new TreeMap<Integer,Integer>();
+    _iVarValues = new TreeMap<Integer,BigInteger>();
     _sVarValues = new TreeMap<Integer,String>();
   }
 
@@ -41,9 +42,9 @@ public class Valuation {
   }
 
   /** Returns the valuation for the integer variable with the given index */
-  public int queryIntAssignment(int index) {
+  public BigInteger queryIntAssignment(int index) {
     if (_iVarValues.containsKey(index)) return _iVarValues.get(index);
-    else return 4242;
+    else return BigInteger.valueOf(4242);
   }
 
   /** Returns the valuation for the string variable with the given index */
@@ -58,7 +59,7 @@ public class Valuation {
   }
 
   /** Returns the valuation for the given integer variable */
-  public int queryAssignment(IVar x) {
+  public BigInteger queryAssignment(IVar x) {
     return queryIntAssignment(x.queryIndex());
   }
 
@@ -74,8 +75,13 @@ public class Valuation {
   }
 
   /** Set an integer variable to the given value. */
-  public void setInt(int index, int value) {
+  public void setInt(int index, BigInteger value) {
     _iVarValues.put(index, value);
+  }
+
+  /** Convenience overload of {@link #setInt(int, BigInteger)} for a small (Java int) value. */
+  public void setInt(int index, int value) {
+    setInt(index, BigInteger.valueOf(value));
   }
 
   /** Set a String variable to the given value. */

--- a/app/src/main/java/charlie/smt/Valuation.java
+++ b/app/src/main/java/charlie/smt/Valuation.java
@@ -44,7 +44,9 @@ public class Valuation {
   /** Returns the valuation for the integer variable with the given index */
   public BigInteger queryIntAssignment(int index) {
     if (_iVarValues.containsKey(index)) return _iVarValues.get(index);
-    else return BigInteger.valueOf(4242);
+    else {
+      return BigInteger.valueOf(4242);
+    }
   }
 
   /** Returns the valuation for the string variable with the given index */

--- a/app/src/main/java/charlie/smt/Valuation.java
+++ b/app/src/main/java/charlie/smt/Valuation.java
@@ -44,9 +44,7 @@ public class Valuation {
   /** Returns the valuation for the integer variable with the given index */
   public BigInteger queryIntAssignment(int index) {
     if (_iVarValues.containsKey(index)) return _iVarValues.get(index);
-    else {
-      return BigInteger.valueOf(4242);
-    }
+    else return BigInteger.valueOf(4242);
   }
 
   /** Returns the valuation for the string variable with the given index */

--- a/app/src/main/java/charlie/solvesmt/SExpression.java
+++ b/app/src/main/java/charlie/solvesmt/SExpression.java
@@ -15,6 +15,7 @@
 
 package charlie.solvesmt;
 
+import java.math.BigInteger;
 import java.util.List;
 
 /**
@@ -22,8 +23,8 @@ import java.util.List;
  * It is very possible that more options will be added in the future, so treat with caution.
  */
 sealed interface SExpression {
-  public record Numeral(int num) implements SExpression {
-    public String toString() { return "" + num; }
+  public record Numeral(BigInteger num) implements SExpression {
+    public String toString() { return num.toString(); }
   }
   public record StringConstant(String text) implements SExpression {
     public String toString() { return "" + text.replace("\"", "\"\""); }

--- a/app/src/main/java/charlie/solvesmt/SMTLibResponseHandler.java
+++ b/app/src/main/java/charlie/solvesmt/SMTLibResponseHandler.java
@@ -115,7 +115,9 @@ class SMTLibResponseHandler {
       }
     }
     else if (kind == 2) {
-      if (result instanceof SExpression.Numeral(java.math.BigInteger i)) val.setInt(index, i);
+      if (result instanceof SExpression.Numeral(java.math.BigInteger i)) {
+        val.setInt(index, i);
+      }
       if (result instanceof SExpression.SExpList(List<SExpression> lst)) {
         if (lst.size() == 2 && lst.get(0) instanceof SExpression.Symbol(String name) &&
           name.equals("-") && lst.get(1) instanceof SExpression.Numeral(java.math.BigInteger k)) {

--- a/app/src/main/java/charlie/solvesmt/SMTLibResponseHandler.java
+++ b/app/src/main/java/charlie/solvesmt/SMTLibResponseHandler.java
@@ -115,9 +115,7 @@ class SMTLibResponseHandler {
       }
     }
     else if (kind == 2) {
-      if (result instanceof SExpression.Numeral(java.math.BigInteger i)) {
-        val.setInt(index, i);
-      }
+      if (result instanceof SExpression.Numeral(java.math.BigInteger i)) val.setInt(index, i);
       if (result instanceof SExpression.SExpList(List<SExpression> lst)) {
         if (lst.size() == 2 && lst.get(0) instanceof SExpression.Symbol(String name) &&
           name.equals("-") && lst.get(1) instanceof SExpression.Numeral(java.math.BigInteger k)) {

--- a/app/src/main/java/charlie/solvesmt/SMTLibResponseHandler.java
+++ b/app/src/main/java/charlie/solvesmt/SMTLibResponseHandler.java
@@ -115,11 +115,11 @@ class SMTLibResponseHandler {
       }
     }
     else if (kind == 2) {
-      if (result instanceof SExpression.Numeral(int i)) val.setInt(index, i);
+      if (result instanceof SExpression.Numeral(java.math.BigInteger i)) val.setInt(index, i);
       if (result instanceof SExpression.SExpList(List<SExpression> lst)) {
         if (lst.size() == 2 && lst.get(0) instanceof SExpression.Symbol(String name) &&
-          name.equals("-") && lst.get(1) instanceof SExpression.Numeral(int k)) {
-          val.setInt(index, -k);
+          name.equals("-") && lst.get(1) instanceof SExpression.Numeral(java.math.BigInteger k)) {
+          val.setInt(index, k.negate());
         }
       }
     }

--- a/app/src/main/java/charlie/solvesmt/SmtParser.java
+++ b/app/src/main/java/charlie/solvesmt/SmtParser.java
@@ -16,6 +16,7 @@
 package charlie.solvesmt;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,10 +91,10 @@ class SmtParser {
   public SExpression readExpression() {
     Token tok = _status.readNextIf(SmtTokenData.NUMERAL);
     if (tok != null) {
-      try { return new SExpression.Numeral(Integer.parseInt(tok.getText())); }
+      try { return new SExpression.Numeral(new BigInteger(tok.getText())); }
       catch (NumberFormatException e) {
         return new SExpression.Symbol(tok.getText());
-          // likely a bigint or something, do what we can to avoid an unnecessary error
+          // not a plain integer (e.g. a hex/binary literal); do what we can to avoid an error
       }
     }
     tok = _status.readNextIf(SmtTokenData.STRING);

--- a/app/src/main/java/charlie/terms/BooleanValue.java
+++ b/app/src/main/java/charlie/terms/BooleanValue.java
@@ -60,4 +60,8 @@ class BooleanValue extends ValueInherit {
   public int getInt() {
     throw new InappropriatePatternDataException("BooleanValue", "getInt", "integer values");
   }
+
+  public java.math.BigInteger getInteger() {
+    throw new InappropriatePatternDataException("BooleanValue", "getInteger", "integer values");
+  }
 }

--- a/app/src/main/java/charlie/terms/IntegerValue.java
+++ b/app/src/main/java/charlie/terms/IntegerValue.java
@@ -15,44 +15,55 @@
 
 package charlie.terms;
 
+import java.math.BigInteger;
 import java.util.Map;
 import charlie.types.TypeFactory;
 
 /**
  * IntegerValues are the function symbols 0, 1, 2, ..., -1, -2, ...
  * They are theory symbols, and specifically correspond to the elements of the mathematical set
- * Z of integer numbers.
+ * Z of integer numbers.  Since Z is unbounded, the value is stored as an arbitrary-precision
+ * BigInteger.
  */
 class IntegerValue extends ValueInherit {
-  private final int _value;
+  private final BigInteger _value;
 
-  IntegerValue(int i) {
+  IntegerValue(BigInteger i) {
     super(TypeFactory.intSort);
     _value = i;
   }
 
+  /** Convenience constructor for the common case of a small (Java int) value. */
+  IntegerValue(int i) {
+    this(BigInteger.valueOf(i));
+  }
+
   /** Returns the string representation of this integer. */
   public String queryName() {
-    return "" + _value;
+    return _value.toString();
   }
 
   /** Returns the standard string representation of the symbol. */
   public String toUniqueString() {
-    return "" + _value;
+    return _value.toString();
   }
 
   public boolean equals(FunctionSymbol symbol) {
     if (symbol == null) return false;
     if (!symbol.isValue()) return false;
     if (!symbol.queryType().equals(TypeFactory.intSort)) return false;
-    return symbol.toValue().getInt() == _value;
+    return symbol.toValue().getInteger().equals(_value);
   }
 
   public int hashCode(Map<Variable,Integer> mu) {
-    return _value;
+    return _value.hashCode();
   }
 
   public int getInt() {
+    return _value.intValueExact();
+  }
+
+  public BigInteger getInteger() {
     return _value;
   }
 

--- a/app/src/main/java/charlie/terms/StringValue.java
+++ b/app/src/main/java/charlie/terms/StringValue.java
@@ -97,6 +97,10 @@ class StringValue extends ValueInherit {
     throw new InappropriatePatternDataException("StringValue", "getInt", "integer values");
   }
 
+  public java.math.BigInteger getInteger() {
+    throw new InappropriatePatternDataException("StringValue", "getInteger", "integer values");
+  }
+
   public String getString() {
     return _value;
   }

--- a/app/src/main/java/charlie/terms/TermPrinter.java
+++ b/app/src/main/java/charlie/terms/TermPrinter.java
@@ -406,7 +406,9 @@ public class TermPrinter {
     boolean brackets = arg.isFunctionalTerm() && arg.queryRoot().toCalculationSymbol() != null;
     if (!brackets && arg.isValue()) {
       Value v = arg.toValue();
-      if (v.isIntegerValue() && v.getInteger().signum() < 0) brackets = true;
+      if (v.isIntegerValue() && v.getInteger().signum() < 0) {
+        brackets = true;
+      }
     }
     builder.append(queryCalculationName(rootsymb.queryKind(), rootsymb.queryName(),
                                         rootsymb.queryType()));

--- a/app/src/main/java/charlie/terms/TermPrinter.java
+++ b/app/src/main/java/charlie/terms/TermPrinter.java
@@ -406,9 +406,7 @@ public class TermPrinter {
     boolean brackets = arg.isFunctionalTerm() && arg.queryRoot().toCalculationSymbol() != null;
     if (!brackets && arg.isValue()) {
       Value v = arg.toValue();
-      if (v.isIntegerValue() && v.getInteger().signum() < 0) {
-        brackets = true;
-      }
+      if (v.isIntegerValue() && v.getInteger().signum() < 0) brackets = true;
     }
     builder.append(queryCalculationName(rootsymb.queryKind(), rootsymb.queryName(),
                                         rootsymb.queryType()));

--- a/app/src/main/java/charlie/terms/TermPrinter.java
+++ b/app/src/main/java/charlie/terms/TermPrinter.java
@@ -406,7 +406,7 @@ public class TermPrinter {
     boolean brackets = arg.isFunctionalTerm() && arg.queryRoot().toCalculationSymbol() != null;
     if (!brackets && arg.isValue()) {
       Value v = arg.toValue();
-      if (v.isIntegerValue() && v.getInt() < 0) brackets = true;
+      if (v.isIntegerValue() && v.getInteger().signum() < 0) brackets = true;
     }
     builder.append(queryCalculationName(rootsymb.queryKind(), rootsymb.queryName(),
                                         rootsymb.queryType()));
@@ -446,10 +446,10 @@ public class TermPrinter {
         rootname = "-";
         right = right.queryArgument(1);
       }
-      else if (right.isValue() && right.toValue().getInt() < 0) {
+      else if (right.isValue() && right.toValue().getInteger().signum() < 0) {
         rootkind = CalculationSymbol.Kind.MINUS;
         rootname = "-";
-        right = new IntegerValue(-right.toValue().getInt());
+        right = new IntegerValue(right.toValue().getInteger().negate());
       }
     }
 

--- a/app/src/main/java/charlie/terms/TheoryFactory.java
+++ b/app/src/main/java/charlie/terms/TheoryFactory.java
@@ -62,6 +62,11 @@ public class TheoryFactory {
     return new IntegerValue(n);
   }
 
+  /** Create an Integer Value from an arbitrary-precision integer */
+  public static Value createValue(java.math.BigInteger n) {
+    return new IntegerValue(n);
+  }
+
   /** Create a Boolean Value */
   public static Value createValue(boolean b) {
     return new BooleanValue(b);

--- a/app/src/main/java/charlie/terms/Value.java
+++ b/app/src/main/java/charlie/terms/Value.java
@@ -35,10 +35,18 @@ public interface Value extends FunctionSymbol {
   public boolean isStringValue();
 
   /**
-   * For integer values, this returns the underlying integer; for other values, it causes an
-   * InappropriatePatternDataException to be thrown.
+   * For integer values, this returns the underlying integer as a (potentially small) int; for
+   * other values, it causes an InappropriatePatternDataException to be thrown.  Note that the
+   * Int sort models the unbounded integers Z, so this may throw an ArithmeticException if the
+   * value does not fit in an int; use getInteger() when the value may be large.
    */
   public int getInt();
+
+  /**
+   * For integer values, this returns the underlying (arbitrary-precision) integer; for other
+   * values, it causes an InappropriatePatternDataException to be thrown.
+   */
+  public java.math.BigInteger getInteger();
 
   /**
    * For string values, this returns the underlying string; for other values, it causes an

--- a/app/src/main/java/charlie/theorytranslation/TermSmtTranslator.java
+++ b/app/src/main/java/charlie/theorytranslation/TermSmtTranslator.java
@@ -171,7 +171,9 @@ public class TermSmtTranslator {
     }
     if (t.isValue()) {
       Value v = t.toValue();
-      if (v.isIntegerValue()) return new Exp.I(SmtFactory.createValue(v.getInteger()));
+      if (v.isIntegerValue()) {
+        return new Exp.I(SmtFactory.createValue(v.getInteger()));
+      }
       if (v.isStringValue()) return new Exp.S(SmtFactory.createValue(v.getString()));
       if (v.isBooleanValue()) return new Exp.B(SmtFactory.createValue(v.getBool()));
       throw new UnsupportedTheoryException("Failed to translate term ", t, " to SMT: this is a " +

--- a/app/src/main/java/charlie/theorytranslation/TermSmtTranslator.java
+++ b/app/src/main/java/charlie/theorytranslation/TermSmtTranslator.java
@@ -171,9 +171,7 @@ public class TermSmtTranslator {
     }
     if (t.isValue()) {
       Value v = t.toValue();
-      if (v.isIntegerValue()) {
-        return new Exp.I(SmtFactory.createValue(v.getInteger()));
-      }
+      if (v.isIntegerValue()) return new Exp.I(SmtFactory.createValue(v.getInteger()));
       if (v.isStringValue()) return new Exp.S(SmtFactory.createValue(v.getString()));
       if (v.isBooleanValue()) return new Exp.B(SmtFactory.createValue(v.getBool()));
       throw new UnsupportedTheoryException("Failed to translate term ", t, " to SMT: this is a " +

--- a/app/src/main/java/charlie/theorytranslation/TermSmtTranslator.java
+++ b/app/src/main/java/charlie/theorytranslation/TermSmtTranslator.java
@@ -171,7 +171,7 @@ public class TermSmtTranslator {
     }
     if (t.isValue()) {
       Value v = t.toValue();
-      if (v.isIntegerValue()) return new Exp.I(SmtFactory.createValue(v.getInt()));
+      if (v.isIntegerValue()) return new Exp.I(SmtFactory.createValue(v.getInteger()));
       if (v.isStringValue()) return new Exp.S(SmtFactory.createValue(v.getString()));
       if (v.isBooleanValue()) return new Exp.B(SmtFactory.createValue(v.getBool()));
       throw new UnsupportedTheoryException("Failed to translate term ", t, " to SMT: this is a " +

--- a/app/src/main/java/cora/termination/dependency_pairs/AccessibilityChecker.java
+++ b/app/src/main/java/cora/termination/dependency_pairs/AccessibilityChecker.java
@@ -209,7 +209,7 @@ class AccessibilityProofObject implements ProofObject {
   AccessibilityProofObject(Valuation solution, TreeMap<String,IVar> sortVariables) {
     _sorts = new ArrayList<Pair<String,Integer>>();
     sortVariables.forEach( (x, v) -> {
-      _sorts.add(new Pair<String,Integer>(x, solution.queryAssignment(v)));
+      _sorts.add(new Pair<String,Integer>(x, solution.queryAssignment(v).intValueExact()));
     });
     Collections.sort(_sorts, new Comparator<Pair<String,Integer>>() {
       public int compare(Pair<String,Integer> p1, Pair<String,Integer> p2) {

--- a/app/src/main/java/cora/termination/dependency_pairs/processors/IntegerMappingProcessor.java
+++ b/app/src/main/java/cora/termination/dependency_pairs/processors/IntegerMappingProcessor.java
@@ -365,7 +365,7 @@ public class IntegerMappingProcessor implements Processor {
     List<DP> remainingDPs = new ArrayList<DP>();
     intMap.forEach(
       (f, ivar) -> {
-        candFun.put(f, _candidates.get(f).get(result.queryAssignment(ivar)));
+        candFun.put(f, _candidates.get(f).get(result.queryAssignment(ivar).intValueExact()));
       }); 
     for (int index = 0; index < originalDPs.size(); index++) {
       DP dp = originalDPs.get(index);

--- a/app/src/main/java/cora/termination/dependency_pairs/processors/SubtermProcessor.java
+++ b/app/src/main/java/cora/termination/dependency_pairs/processors/SubtermProcessor.java
@@ -144,7 +144,7 @@ public class SubtermProcessor implements Processor {
     Valuation v = valuation;  // local variables referenced from a lambda expression must be effectively final
     fSharpMap.forEach(
       (f, ivar) -> {
-        nu.put(f, v.queryAssignment(ivar));
+        nu.put(f, v.queryAssignment(ivar).intValueExact());
       });
     for (int index = 0; index < originalDPs.size(); index++) {
       DP dp = originalDPs.get(index);

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
@@ -26,6 +26,7 @@ import cora.termination.reduction_pairs.*;
 import cora.termination.reduction_pairs.horpo.HorpoConstraintList.HRelation;
 import cora.termination.reduction_pairs.horpo.HorpoConstraintList.HorpoRequirement;
 
+import java.math.BigInteger;
 import java.util.*;
 
 /**
@@ -130,24 +131,28 @@ public class Horpo implements ReductionPair {
    * a lambda-expression must be effectively final, so it is necessary to wrap our very much
    * non-final variable in a class.
    */
-  private class IntWrapper { int num; IntWrapper(int n) { num = n; } }
+  private class BigWrapper { BigInteger num; BigWrapper(BigInteger n) { num = n; } }
 
   /**
-   * Returns twice the largest integer value occurring in the given OrderingProblem, or 1000 if
-   * that is bigger.
+   * Returns twice the largest absolute integer value occurring in the given OrderingProblem, or
+   * 1000 if that is bigger.  Since the Int sort is unbounded, a value may exceed the int range; as
+   * the bound only sizes the (int-bounded) SMT search space, an astronomically large constant just
+   * saturates it at Integer.MAX_VALUE rather than overflowing or throwing.
    */
   private int computeIntegerVariableBound(OrderingProblem problem) {
-    IntWrapper wrapper = new IntWrapper(500);
+    BigWrapper wrapper = new BigWrapper(BigInteger.valueOf(500));
     for (Term term : getAllTerms(problem)) {
       term.visitSubterms( (s,p) -> {
         if (s.isValue() && s.queryType().equals(TypeFactory.intSort)) {
-          Value value = s.toValue();
-          if (value.getInt() > wrapper.num) wrapper.num = value.getInt();
-          if (- value.getInt() > wrapper.num) wrapper.num = - value.getInt();
+          BigInteger abs = s.toValue().getInteger().abs();
+          if (abs.compareTo(wrapper.num) > 0) wrapper.num = abs;
         }
       });
     }
-    return wrapper.num * 2;
+    // Saturating only costs completeness, never soundness; widening the SMT bound to BigInteger
+    // would be the upgrade path for larger constants.
+    return wrapper.num.multiply(BigInteger.TWO).min(BigInteger.valueOf(Integer.MAX_VALUE))
+                      .intValueExact();
   }
 
   /**

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
@@ -73,7 +73,7 @@ public class Horpo implements ReductionPair {
 
   /** Main access function: start a HORPO proof to generate a suitable reduction pair. */
   public ReductionPairProofObject solve(OrderingProblem problem, SmtProblem smt) {
-    int bound = computeIntegerVariableBound(problem);
+    BigInteger bound = computeIntegerVariableBound(problem);
     TreeSet<FunctionSymbol> symbols = getFunctionSymbols(problem);
     ArgumentFilter filter = problem.queryArgumentFilter();
     HorpoParameters param = new HorpoParameters(bound, symbols, filter, smt);
@@ -135,11 +135,9 @@ public class Horpo implements ReductionPair {
 
   /**
    * Returns twice the largest absolute integer value occurring in the given OrderingProblem, or
-   * 1000 if that is bigger.  Since the Int sort is unbounded, a value may exceed the int range; as
-   * the bound only sizes the (int-bounded) SMT search space, an astronomically large constant just
-   * saturates it at Integer.MAX_VALUE rather than overflowing or throwing.
+   * 1000 if that is bigger.
    */
-  private int computeIntegerVariableBound(OrderingProblem problem) {
+  private BigInteger computeIntegerVariableBound(OrderingProblem problem) {
     BigWrapper wrapper = new BigWrapper(BigInteger.valueOf(500));
     for (Term term : getAllTerms(problem)) {
       term.visitSubterms( (s,p) -> {
@@ -149,10 +147,7 @@ public class Horpo implements ReductionPair {
         }
       });
     }
-    // Saturating only costs completeness, never soundness; widening the SMT bound to BigInteger
-    // would be the upgrade path for larger constants.
-    return wrapper.num.multiply(BigInteger.TWO).min(BigInteger.valueOf(Integer.MAX_VALUE))
-                      .intValueExact();
+    return wrapper.num.multiply(BigInteger.TWO);
   }
 
   /**

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
@@ -143,9 +143,7 @@ public class Horpo implements ReductionPair {
       term.visitSubterms( (s,p) -> {
         if (s.isValue() && s.queryType().equals(TypeFactory.intSort)) {
           BigInteger abs = s.toValue().getInteger().abs();
-          if (abs.compareTo(wrapper.num) > 0) {
-            wrapper.num = abs;
-          }
+          if (abs.compareTo(wrapper.num) > 0) wrapper.num = abs;
         }
       });
     }

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/Horpo.java
@@ -143,7 +143,9 @@ public class Horpo implements ReductionPair {
       term.visitSubterms( (s,p) -> {
         if (s.isValue() && s.queryType().equals(TypeFactory.intSort)) {
           BigInteger abs = s.toValue().getInteger().abs();
-          if (abs.compareTo(wrapper.num) > 0) wrapper.num = abs;
+          if (abs.compareTo(wrapper.num) > 0) {
+            wrapper.num = abs;
+          }
         }
       });
     }

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoParameters.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoParameters.java
@@ -15,6 +15,7 @@
 
 package cora.termination.reduction_pairs.horpo;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.TreeMap;
@@ -35,7 +36,7 @@ class HorpoParameters {
   private final TreeMap<FunctionSymbol,IVar> _precedence;
   private final TreeMap<FunctionSymbol,TreeMap<Integer,IVar>> _permutation;
   private final BVar _down;
-  private final int _M;
+  private final BigInteger _M;
 
   /**
    * This sets up a set of HorpoParameters by generating boolean and integer variables in the SMT
@@ -43,13 +44,13 @@ class HorpoParameters {
    * for N_f, because we implicitly assume that N_f is the maximum arity of any function symbol,
    * and since the set is finite, such number always exists.
    */
-  HorpoParameters(int bound, TreeSet<FunctionSymbol> allsymbols, ArgumentFilter regards,
+  HorpoParameters(BigInteger bound, TreeSet<FunctionSymbol> allsymbols, ArgumentFilter regards,
                   SmtProblem problem) {
     _problem = problem;
     _precedence = new TreeMap<FunctionSymbol,IVar>();
     _permutation = new TreeMap<FunctionSymbol,TreeMap<Integer,IVar>>();
     _down = _problem.createBooleanVariable("down");
-    _M = bound > 0 ? bound : 1;
+    _M = bound.signum() > 0 ? bound : BigInteger.ONE;
     setupPrecedence(allsymbols);
     setupPermutation(allsymbols, regards);
   }
@@ -159,7 +160,7 @@ class HorpoParameters {
    *
    * This is the value the HorpoParameters were initialised with.
    */
-  int queryIntegerBound() {
+  BigInteger queryIntegerBound() {
     return _M;
   }
 

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoParameters.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoParameters.java
@@ -188,12 +188,12 @@ class HorpoParameters {
   public ArrayList<SymbolData> getSymbolData(Valuation valuation) {
     ArrayList<SymbolData> info = new ArrayList<SymbolData>();
     for (FunctionSymbol symbol : _precedence.keySet()) {
-      int p = valuation.queryAssignment(_precedence.get(symbol));
+      int p = valuation.queryAssignment(_precedence.get(symbol)).intValueExact();
       TreeSet<Integer> one = new TreeSet<Integer>();
       TreeMap<Integer,Integer> other = new TreeMap<Integer,Integer>();
       for (int i = 1; i <= symbol.queryArity(); i++) {
         IVar x = _permutation.get(symbol).get(i);
-        int value = valuation.queryAssignment(x);
+        int value = valuation.queryAssignment(x).intValueExact();
         if (value == 1) one.add(i);
         else if (value > 1) other.put(value, i);
       }

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
@@ -75,14 +75,14 @@ class HorpoResult extends ReductionPairProofObject {
   public int precedence(FunctionSymbol f, FunctionSymbol g) {
     int fi, gi;
     if (_valuation == null) return 0;
-    int k = _parameters.getPrecedence(f).evaluate(_valuation) -
-            _parameters.getPrecedence(g).evaluate(_valuation);
+    int k = _parameters.getPrecedence(f).evaluate(_valuation).subtract(
+            _parameters.getPrecedence(g).evaluate(_valuation)).intValue();
     return k;
   }
 
   public int permutation(FunctionSymbol f, int index) {
     if (_valuation == null) return 0;
-    return _parameters.getPermutation(f, index).evaluate(_valuation);
+    return _parameters.getPermutation(f, index).evaluate(_valuation).intValueExact();
   }
 
   /** Returns whether the ordering is inherently strict. */

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
@@ -96,12 +96,8 @@ class HorpoResult extends ReductionPairProofObject {
     module.print("{(x,y) | ");
     boolean down = _parameters.getDirectionIsDownVariable().evaluate(_valuation);
     BigInteger bound = _parameters.queryIntegerBound();
-    if (down) {
-      module.print("x %{greater} -%a %{and} x %{greater} y }", bound.toString());
-    }
-    else {
-      module.print("x %{smaller} %a %{and} x %{smaller} y }", bound.toString());
-    }
+    if (down) module.print("x %{greater} -%a %{and} x %{greater} y }", bound.toString());
+    else module.print("x %{smaller} %a %{and} x %{smaller} y }", bound.toString());
   }
 
   /** Returns the set of all function symbols in the requirements we oriented. */

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
@@ -96,8 +96,12 @@ class HorpoResult extends ReductionPairProofObject {
     module.print("{(x,y) | ");
     boolean down = _parameters.getDirectionIsDownVariable().evaluate(_valuation);
     BigInteger bound = _parameters.queryIntegerBound();
-    if (down) module.print("x %{greater} -%a %{and} x %{greater} y }", bound.toString());
-    else module.print("x %{smaller} %a %{and} x %{smaller} y }", bound.toString());
+    if (down) {
+      module.print("x %{greater} -%a %{and} x %{greater} y }", bound.toString());
+    }
+    else {
+      module.print("x %{smaller} %a %{and} x %{smaller} y }", bound.toString());
+    }
   }
 
   /** Returns the set of all function symbols in the requirements we oriented. */

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoResult.java
@@ -15,6 +15,7 @@
 
 package cora.termination.reduction_pairs.horpo;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.TreeMap;
 import java.util.Set;
@@ -94,9 +95,9 @@ class HorpoResult extends ReductionPairProofObject {
   private void printIntegerOrdering(OutputModule module) {
     module.print("{(x,y) | ");
     boolean down = _parameters.getDirectionIsDownVariable().evaluate(_valuation);
-    int bound = _parameters.queryIntegerBound();
-    if (down) module.print("x %{greater} -%a %{and} x %{greater} y }", bound);
-    else module.print("x %{smaller} %a %{and} x %{smaller} y }", bound);
+    BigInteger bound = _parameters.queryIntegerBound();
+    if (down) module.print("x %{greater} -%a %{and} x %{greater} y }", bound.toString());
+    else module.print("x %{smaller} %a %{and} x %{smaller} y }", bound.toString());
   }
 
   /** Returns the set of all function symbols in the requirements we oriented. */

--- a/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoSimplifier.java
+++ b/app/src/main/java/cora/termination/reduction_pairs/horpo/HorpoSimplifier.java
@@ -15,6 +15,7 @@
 
 package cora.termination.reduction_pairs.horpo;
 
+import java.math.BigInteger;
 import charlie.util.Pair;
 import charlie.types.*;
 import charlie.terms.replaceable.Replaceable;
@@ -286,7 +287,7 @@ class HorpoSimplifier {
 
     Constraint downProblem, upProblem;
     if (rel == HRelation.GREATERTHEORY) {
-      IntegerExpression eMM = SmtFactory.createValue(-_parameters.queryIntegerBound());
+      IntegerExpression eMM = SmtFactory.createValue(_parameters.queryIntegerBound().negate());
       downProblem = SmtFactory.createConjunction(  // l > r ∧ l ≥ -M
         SmtFactory.createGreater(el, er), SmtFactory.createGeq(el, eMM) );
       eMM = SmtFactory.createValue(_parameters.queryIntegerBound());

--- a/app/src/test/java/charlie/parser/CoraTermsParsingTest.java
+++ b/app/src/test/java/charlie/parser/CoraTermsParsingTest.java
@@ -79,6 +79,14 @@ public class CoraTermsParsingTest {
     term = readTerm("0", true, "");
     assertTrue(term instanceof IntVal);
     assertTrue(term.toString().equals("0"));
+    // The Int sort models the unbounded integers Z, so values beyond the 32-bit and 64-bit ranges
+    // parse fine (the old int-based parser overflowed Integer.parseInt on these).
+    term = readTerm("2147483648", true, "");  // Integer.MAX_VALUE + 1
+    assertTrue(term instanceof IntVal);
+    assertTrue(term.toString().equals("2147483648"));
+    term = readTerm("123456789123456789123456789", true, "");
+    assertTrue(term instanceof IntVal);
+    assertTrue(term.toString().equals("123456789123456789123456789"));
   }
 
   @Test
@@ -89,6 +97,9 @@ public class CoraTermsParsingTest {
     term = readTerm("-1", true, "");
     assertTrue(term instanceof IntVal);
     assertTrue(term.toString().equals("-1"));
+    term = readTerm("-2147483648", true, "");  // i32::MIN, unrepresentable by the old int parser
+    assertTrue(term instanceof IntVal);
+    assertTrue(term.toString().equals("-2147483648"));
   }
 
   @Test
@@ -99,10 +110,6 @@ public class CoraTermsParsingTest {
     term = readTerm("017", true, "1:1: Illegal integer constant: 017.\n");
     assertTrue(term instanceof IntVal);
     assertTrue(term.toString().equals("17"));
-    term = readTerm("123456789123456789", true,
-      "1:1: Cannot parse integer constant: 123456789123456789\n");
-    assertTrue(term instanceof Identifier);
-    assertTrue(term.toString().equals("123456789123456789"));
   }
 
   @Test

--- a/app/src/test/java/charlie/smt/AdditionTest.java
+++ b/app/src/test/java/charlie/smt/AdditionTest.java
@@ -17,6 +17,7 @@ package charlie.smt;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import java.math.BigInteger;
 import java.util.List;
 import charlie.util.Pair;
 
@@ -111,7 +112,21 @@ public class AdditionTest {
   public void testLegalEvaluate() {
     IntegerExpression plus =
       new Addition(new IValue(3), new Addition(new IValue(12), new IValue(-2)));
-    assertTrue(plus.evaluate() == 13);
+    assertTrue(plus.evaluate().intValueExact() == 13);
+  }
+
+  @Test
+  public void testLargeCoefficientSimplifyDoesNotOverflow() {
+    // 2000000000 * x + 2000000000 * x = 4000000000 * x.  The accumulated coefficient 4000000000
+    // overflows a 32-bit int, so this exercises the BigInteger coefficient accumulation in
+    // simplify().
+    IVar x = new IVar(3);
+    BigInteger big = BigInteger.valueOf(2000000000L);
+    IntegerExpression simplified = new Addition(new CMult(big, x), new CMult(big, x)).simplify();
+    assertTrue(simplified.equals(new CMult(BigInteger.valueOf(4000000000L), x)));
+    Valuation val = new Valuation();
+    val.setInt(3, 1);
+    assertTrue(simplified.evaluate(val).equals(BigInteger.valueOf(4000000000L)));
   }
 
   @Test

--- a/app/src/test/java/charlie/smt/CMultTest.java
+++ b/app/src/test/java/charlie/smt/CMultTest.java
@@ -35,7 +35,7 @@ public class CMultTest {
       new CMult(1,
       new CMult(3,
       new Multiplication(new IValue(3), new IValue(-5)))));
-    assertTrue(minus.evaluate() == 90);
+    assertTrue(minus.evaluate().intValueExact() == 90);
   }
 
   @Test

--- a/app/src/test/java/charlie/smt/DivModTest.java
+++ b/app/src/test/java/charlie/smt/DivModTest.java
@@ -43,8 +43,8 @@ public class DivModTest {
     // tests whether divide and modulo follow the definitions by Boute
     for (int num = -5; num <= 5; num++) {
       for (int denom = -3; denom <= 3; denom++) {
-        int d = (new Division(new IValue(num), new IValue(denom))).evaluate();
-        int m = (new Modulo(new IValue(num), new IValue(denom))).evaluate();
+        int d = (new Division(new IValue(num), new IValue(denom))).evaluate().intValueExact();
+        int m = (new Modulo(new IValue(num), new IValue(denom))).evaluate().intValueExact();
         String situation = "" + num + " / " + denom + " = " + d + " and " +
                                 num + " % " + denom + " = " + m;
         if (denom == 0) {

--- a/app/src/test/java/charlie/smt/IValueTest.java
+++ b/app/src/test/java/charlie/smt/IValueTest.java
@@ -22,7 +22,7 @@ public class IValueTest {
   @Test
   public void testBasics() {
     IValue x = new IValue(-3);
-    assertTrue(x.evaluate() == -3);
+    assertTrue(x.evaluate().intValueExact() == -3);
     assertTrue(x.toString().equals("-3"));
     assertTrue(x.toSmtString().equals("(- 3)"));
     assertTrue(x.multiply(5).equals(new IValue(-15)));

--- a/app/src/test/java/charlie/smt/MultiplicationTest.java
+++ b/app/src/test/java/charlie/smt/MultiplicationTest.java
@@ -17,6 +17,7 @@ package charlie.smt;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import java.math.BigInteger;
 import java.util.List;
 
 public class MultiplicationTest {
@@ -47,7 +48,16 @@ public class MultiplicationTest {
   public void testLegalEvaluate() {
     IntegerExpression prod =
       new Multiplication(new IValue(3), new Multiplication(new IValue(12), new IValue(-2)));
-    assertTrue(prod.evaluate() == -72);
+    assertTrue(prod.evaluate().intValueExact() == -72);
+  }
+
+  @Test
+  public void testLargeValueEvaluateDoesNotOverflow() {
+    // 3000000000 * 3000000000 = 9 * 10^18, which overflows a 32-bit int; BigInteger evaluation
+    // computes it exactly.
+    BigInteger big = BigInteger.valueOf(3000000000L);
+    IntegerExpression prod = new Multiplication(new IValue(big), new IValue(big));
+    assertTrue(prod.evaluate().equals(new BigInteger("9000000000000000000")));
   }
 
   @Test

--- a/app/src/test/java/charlie/solvesmt/SharedSmtSolversTest.java
+++ b/app/src/test/java/charlie/solvesmt/SharedSmtSolversTest.java
@@ -97,8 +97,9 @@ public class SharedSmtSolversTest {
     Answer a = solver.checkSatisfiability(problem);
     if (a instanceof Answer.YES(Valuation v)) {
       assertTrue(v.queryAssignment(x));
-      assertTrue(v.queryAssignment(z) < 0);
-      assertTrue(v.queryAssignment(y) > 12 || v.queryAssignment(y) == v.queryAssignment(z));
+      assertTrue(v.queryAssignment(z).signum() < 0);
+      assertTrue(v.queryAssignment(y).compareTo(java.math.BigInteger.valueOf(12)) > 0 ||
+                 v.queryAssignment(y).equals(v.queryAssignment(z)));
     }
     else assertTrue(false);
   }

--- a/app/src/test/java/charlie/solvesmt/SmtParserTest.java
+++ b/app/src/test/java/charlie/solvesmt/SmtParserTest.java
@@ -26,11 +26,11 @@ public class SmtParserTest {
   @Test
   public void testReadNumeral() {
     switch (SmtParser.readExpressionFromString("123")) {
-      case SExpression.Numeral(int n): assertTrue(n == 123); break;
+      case SExpression.Numeral(java.math.BigInteger n): assertTrue(n.intValueExact() == 123); break;
       default: assertTrue(false);
     }
     switch (SmtParser.readExpressionFromString("0")) {
-      case SExpression.Numeral(int n): assertTrue(n == 0); break;
+      case SExpression.Numeral(java.math.BigInteger n): assertTrue(n.intValueExact() == 0); break;
       default: assertTrue(false);
     }
     // this should probably give an error in the future, but for now we allow it as an identifier

--- a/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoParametersTest.java
+++ b/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoParametersTest.java
@@ -40,8 +40,8 @@ public class HorpoParametersTest {
   @Test
   public void testBasics() {
     SmtProblem smt = new SmtProblem();
-    HorpoParameters horpo = new HorpoParameters(
-      BigInteger.valueOf(37), new TreeSet<FunctionSymbol>(), new ArgumentFilter(smt), smt);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(37), new TreeSet<FunctionSymbol>(),
+                                                new ArgumentFilter(smt), smt);
     assertTrue(horpo.queryIntegerBound().equals(BigInteger.valueOf(37)));
     BVar x = horpo.getDirectionIsDownVariable();
     assertTrue(x.toString().equals("[down]"));
@@ -60,8 +60,7 @@ public class HorpoParametersTest {
     set.add(g);
     set.add(minus);
     set.add(three);
-    HorpoParameters horpo = new HorpoParameters(
-      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     assertTrue(prob.toString().equals(
       // precedence: 1 ≤ pred(h) ≤ 4 for h ∈ {f,g,minus}, and pred(3) = 0
       "[pred(-)] >= 1\n" +
@@ -93,8 +92,7 @@ public class HorpoParametersTest {
     TreeSet<FunctionSymbol> set = new TreeSet<FunctionSymbol>();
     set.add(f);
     set.add(g);
-    HorpoParameters horpo = new HorpoParameters(
-      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar fx = horpo.getPrecedence(f);
     IVar gx = horpo.getPrecedence(g);
     assertFalse(fx.equals(gx));
@@ -111,8 +109,7 @@ public class HorpoParametersTest {
     TreeSet<FunctionSymbol> set = new TreeSet<FunctionSymbol>();
     set.add(f);
     set.add(g);
-    HorpoParameters horpo = new HorpoParameters(
-      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar f1 = horpo.getPermutation(f, 1);
     IVar g1 = horpo.getPermutation(g, 1);
     assertTrue(g1 == horpo.getPermutation(g, 1));
@@ -133,8 +130,7 @@ public class HorpoParametersTest {
     set.add(h);
     set.add(three);
     set.add(TheoryFactory.createValue(4));
-    HorpoParameters horpo = new HorpoParameters(
-      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar x = horpo.getPrecedence(f);
     IVar y = horpo.getPrecedence(g);
     IVar z = horpo.getPrecedence(h);

--- a/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoParametersTest.java
+++ b/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoParametersTest.java
@@ -40,8 +40,8 @@ public class HorpoParametersTest {
   @Test
   public void testBasics() {
     SmtProblem smt = new SmtProblem();
-    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(37), new TreeSet<FunctionSymbol>(),
-                                                new ArgumentFilter(smt), smt);
+    HorpoParameters horpo = new HorpoParameters(
+      BigInteger.valueOf(37), new TreeSet<FunctionSymbol>(), new ArgumentFilter(smt), smt);
     assertTrue(horpo.queryIntegerBound().equals(BigInteger.valueOf(37)));
     BVar x = horpo.getDirectionIsDownVariable();
     assertTrue(x.toString().equals("[down]"));
@@ -60,7 +60,8 @@ public class HorpoParametersTest {
     set.add(g);
     set.add(minus);
     set.add(three);
-    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(
+      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     assertTrue(prob.toString().equals(
       // precedence: 1 ≤ pred(h) ≤ 4 for h ∈ {f,g,minus}, and pred(3) = 0
       "[pred(-)] >= 1\n" +
@@ -92,7 +93,8 @@ public class HorpoParametersTest {
     TreeSet<FunctionSymbol> set = new TreeSet<FunctionSymbol>();
     set.add(f);
     set.add(g);
-    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(
+      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar fx = horpo.getPrecedence(f);
     IVar gx = horpo.getPrecedence(g);
     assertFalse(fx.equals(gx));
@@ -109,7 +111,8 @@ public class HorpoParametersTest {
     TreeSet<FunctionSymbol> set = new TreeSet<FunctionSymbol>();
     set.add(f);
     set.add(g);
-    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(
+      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar f1 = horpo.getPermutation(f, 1);
     IVar g1 = horpo.getPermutation(g, 1);
     assertTrue(g1 == horpo.getPermutation(g, 1));
@@ -130,7 +133,8 @@ public class HorpoParametersTest {
     set.add(h);
     set.add(three);
     set.add(TheoryFactory.createValue(4));
-    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(
+      BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar x = horpo.getPrecedence(f);
     IVar y = horpo.getPrecedence(g);
     IVar z = horpo.getPrecedence(h);

--- a/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoParametersTest.java
+++ b/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoParametersTest.java
@@ -15,6 +15,7 @@
 
 package cora.termination.reduction_pairs.horpo;
 
+import java.math.BigInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,9 +40,9 @@ public class HorpoParametersTest {
   @Test
   public void testBasics() {
     SmtProblem smt = new SmtProblem();
-    HorpoParameters horpo = new HorpoParameters(37, new TreeSet<FunctionSymbol>(),
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(37), new TreeSet<FunctionSymbol>(),
                                                 new ArgumentFilter(smt), smt);
-    assertTrue(horpo.queryIntegerBound() == 37);
+    assertTrue(horpo.queryIntegerBound().equals(BigInteger.valueOf(37)));
     BVar x = horpo.getDirectionIsDownVariable();
     assertTrue(x.toString().equals("[down]"));
     assertTrue(x == horpo.getDirectionIsDownVariable());
@@ -59,7 +60,7 @@ public class HorpoParametersTest {
     set.add(g);
     set.add(minus);
     set.add(three);
-    HorpoParameters horpo = new HorpoParameters(40, set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     assertTrue(prob.toString().equals(
       // precedence: 1 ≤ pred(h) ≤ 4 for h ∈ {f,g,minus}, and pred(3) = 0
       "[pred(-)] >= 1\n" +
@@ -91,7 +92,7 @@ public class HorpoParametersTest {
     TreeSet<FunctionSymbol> set = new TreeSet<FunctionSymbol>();
     set.add(f);
     set.add(g);
-    HorpoParameters horpo = new HorpoParameters(40, set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar fx = horpo.getPrecedence(f);
     IVar gx = horpo.getPrecedence(g);
     assertFalse(fx.equals(gx));
@@ -108,7 +109,7 @@ public class HorpoParametersTest {
     TreeSet<FunctionSymbol> set = new TreeSet<FunctionSymbol>();
     set.add(f);
     set.add(g);
-    HorpoParameters horpo = new HorpoParameters(40, set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar f1 = horpo.getPermutation(f, 1);
     IVar g1 = horpo.getPermutation(g, 1);
     assertTrue(g1 == horpo.getPermutation(g, 1));
@@ -129,7 +130,7 @@ public class HorpoParametersTest {
     set.add(h);
     set.add(three);
     set.add(TheoryFactory.createValue(4));
-    HorpoParameters horpo = new HorpoParameters(40, set, new ArgumentFilter(prob), prob);
+    HorpoParameters horpo = new HorpoParameters(BigInteger.valueOf(40), set, new ArgumentFilter(prob), prob);
     IVar x = horpo.getPrecedence(f);
     IVar y = horpo.getPrecedence(g);
     IVar z = horpo.getPrecedence(h);

--- a/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoResultTest.java
+++ b/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoResultTest.java
@@ -15,6 +15,7 @@
 
 package cora.termination.reduction_pairs.horpo;
 
+import java.math.BigInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -69,7 +70,7 @@ public class HorpoResultTest {
       Rule r = trs.queryRule(i);
       problem.requireEither(new OrderingRequirement(r, OrderingRequirement.Relation.Strict), i * 2);
     }
-    HorpoParameters param = new HorpoParameters(100,
+    HorpoParameters param = new HorpoParameters(BigInteger.valueOf(100),
       new TreeSet<FunctionSymbol>(trs.queryAlphabet().getSymbols()), filter, smt);
     HorpoConstraintList lst = new HorpoConstraintList(new TermPrinter(Set.of()), smt);
     Valuation valuation = new Valuation();
@@ -143,7 +144,7 @@ public class HorpoResultTest {
       Rule r = trs.queryRule(i);
       problem.requireEither(new OrderingRequirement(r, OrderingRequirement.Relation.Strict), i * 2);
     }
-    HorpoParameters param = new HorpoParameters(3,
+    HorpoParameters param = new HorpoParameters(BigInteger.valueOf(3),
       new TreeSet<FunctionSymbol>(trs.queryAlphabet().getSymbols()), filter, smt);
     HorpoConstraintList lst = new HorpoConstraintList(new TermPrinter(Set.of()), smt);
     Valuation valuation = new Valuation();

--- a/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoSimplifierTest.java
+++ b/app/src/test/java/cora/termination/reduction_pairs/horpo/HorpoSimplifierTest.java
@@ -15,6 +15,7 @@
 
 package cora.termination.reduction_pairs.horpo;
 
+import java.math.BigInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -61,7 +62,7 @@ public class HorpoSimplifierTest {
     HorpoConstraintList lst = makeList(trs, smt);
     ArgumentFilter filter = new ArgumentFilter(smt);
     TreeSet<FunctionSymbol> funcs = new TreeSet<FunctionSymbol>(trs.queryAlphabet().getSymbols());
-    HorpoParameters param = new HorpoParameters(1000, funcs, filter, smt);
+    HorpoParameters param = new HorpoParameters(BigInteger.valueOf(1000), funcs, filter, smt);
     HorpoSimplifier simplifier = new HorpoSimplifier(param, lst, filter);
     Term term = CoraInputReader.readTerm("Q(" + l + ", " + r + ", y, " + phi + ")", trs);
     Term left = term.queryArgument(1);
@@ -103,7 +104,7 @@ public class HorpoSimplifierTest {
     HorpoConstraintList lst = makeList(trs, smt);
     ArgumentFilter filter = new ArgumentFilter(smt);
     TreeSet<FunctionSymbol> funcs = new TreeSet<FunctionSymbol>(trs.queryAlphabet().getSymbols());
-    HorpoParameters param = new HorpoParameters(1000, funcs, filter, smt);
+    HorpoParameters param = new HorpoParameters(BigInteger.valueOf(1000), funcs, filter, smt);
     HorpoSimplifier simplifier = new HorpoSimplifier(param, lst, filter);
     Term left = trs.queryRule(0).queryLeftSide().queryArgument(1);
     Term right = trs.queryRule(0).queryRightSide().queryArgument(1);


### PR DESCRIPTION
Int was a 32-bit Java int at every layer (parser, term model, SMT expression model, model readback), so wide constants failed to parse and internal simplification could silently overflow. Replace the representation with BigInteger throughout; int convenience overloads keep small-int call sites unchanged.

Fixes #9